### PR TITLE
Quasi-Newton Models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,6 @@ notifications:
 before_install:
   - if [ `uname` == "Linux" ]; then unset DYLD_LIBRARY_PATH; bash travisCI/setup_travis_linux.sh; fi
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    wget --no-check-certificate http://www.cmake.org/files/v3.3/cmake-3.3.2-Darwin-x86_64.tar.gz;
-    tar -zxf cmake-3.3.2-Darwin-x86_64.tar.gz;
-    export PATH=`pwd`/cmake-3.3.2-Darwin-x86_64/CMake.app/Contents/bin:$PATH; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    wget --no-check-certificate http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz;
-    tar -xzf cmake-3.3.2-Linux-x86_64.tar.gz;
-    sudo cp -fR cmake-3.3.2-Linux-x86_64/* /usr;
-    export PATH=`pwd`/cmake-3.3.2-Linux-x86_64/bin:$PATH; fi
 
 script:
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("NLPModels"); Pkg.test("NLPModels"; coverage=true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ git:
 notifications:
   email: false
 
+# Github/Travis bug
+# branches:
+#   only:
+#     - master
+
 before_install:
   - if [ `uname` == "Linux" ]; then unset DYLD_LIBRARY_PATH; bash travisCI/setup_travis_linux.sh; fi
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ environment:
   - JULIAVERSION: "stable/win32"
   - JULIAVERSION: "stable/win64"
 
+skip_branch_with_pr: true
+
 install:
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")

--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -215,7 +215,9 @@ with σ = obj_weight.
 """
 function hess_op(nlp :: AbstractNLPModel, x :: Vector{Float64};
                  obj_weight :: Float64=1.0, y :: Vector{Float64}=zeros(nlp.meta.ncon))
-  return LinearOperator(nlp.meta.nvar, Float64, v -> hprod(nlp, x, v; obj_weight=obj_weight, y=y))
+  return LinearOperator(nlp.meta.nvar, nlp.meta.nvar,
+                        true, true,
+                        v -> hprod(nlp, x, v; obj_weight=obj_weight, y=y))
 end
 
 push!(nlp :: AbstractNLPModel, args...; kwargs...) =

--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -12,9 +12,13 @@ export reset!,
        jac_coord, jac, jprod, jprod!, jtprod, jtprod!,
        jth_hprod, jth_hprod!, ghjvprod, ghjvprod!,
        hess_coord, hess, hprod, hprod!, hess_op,
+       push!,
        varscale, lagscale, conscale,
        NotImplementedError
 
+# import methods we override
+import Base.push!
+import LinearOperators.reset!
 
 include("nlp_utils.jl");
 include("nlp_types.jl");
@@ -214,6 +218,8 @@ function hess_op(nlp :: AbstractNLPModel, x :: Vector{Float64};
   return LinearOperator(nlp.meta.nvar, Float64, v -> hprod(nlp, x, v; obj_weight=obj_weight, y=y))
 end
 
+push!(nlp :: AbstractNLPModel, args...; kwargs...) =
+  throw(NotImplementedError("push!"))
 varscale(::AbstractNLPModel, ::AbstractVector) =
   throw(NotImplementedError("varscale"))
 lagscale(::AbstractNLPModel, ::Float64) =
@@ -233,6 +239,7 @@ if Pkg.installed("ForwardDiff") != nothing
 end
 include("simple_model.jl")
 include("slack_model.jl")
+include("qn_model.jl")
 
 include("dercheck.jl")
 

--- a/src/qn_model.jl
+++ b/src/qn_model.jl
@@ -1,0 +1,64 @@
+export QuasiNewtonModel, LBFGSModel, LSR1Model,
+       reset!,
+       obj, grad, grad!,
+       cons, cons!, jac_coord, jac, jprod, jprod!, jtprod, jtprod!,
+       hprod, hess_op,
+       push!
+
+abstract QuasiNewtonModel <: AbstractNLPModel
+
+type LBFGSModel <: QuasiNewtonModel
+  meta :: NLPModelMeta
+  model :: AbstractNLPModel
+  op :: LBFGSOperator
+end
+
+type LSR1Model <: QuasiNewtonModel
+  meta :: NLPModelMeta
+  model :: AbstractNLPModel
+  op :: LSR1Operator
+end
+
+"Construct a `LBFGSModel` from another type of model."
+function LBFGSModel(nlp :: AbstractNLPModel; memory :: Int=5)
+  op = LBFGSOperator(nlp.meta.nvar, memory)
+  return LBFGSModel(nlp.meta, nlp, op)
+end
+
+"Construct a `LSR1Model` from another type of nlp."
+function LSR1Model(nlp :: AbstractNLPModel; memory :: Int=5)
+  op = LSR1Operator(nlp.meta.nvar, memory)
+  return LSR1Model(nlp.meta, nlp, op)
+end
+
+# retrieve counters from underlying model
+for counter in fieldnames(Counters)
+  @eval begin
+    $counter(nlp :: QuasiNewtonModel) = $counter(nlp.model)
+    export $counter
+  end
+end
+
+function reset!(nlp :: QuasiNewtonModel)
+  reset!(nlp.model.counters)
+  reset!(nlp.op)
+  return nlp
+end
+
+# the following methods are not affected by the Hessian approximation
+for meth in (:obj, :grad, :grad!, :cons, :cons!, :jac_coord, :jac, :jprod, :jprod!, :jtprod, :jtprod!)
+  @eval begin
+    $meth(nlp :: QuasiNewtonModel, args...) = $meth(nlp.model, args...)
+  end
+end
+
+# the following methods are affected by the Hessian approximation
+hess_op(nlp :: QuasiNewtonModel, x :: Vector{Float64}; kwargs...) = nlp.op
+hprod(nlp :: QuasiNewtonModel, x :: Vector{Float64}, v :: Vector{Float64}; kwargs...) = nlp.op * v
+
+function push!(nlp :: QuasiNewtonModel, args...)
+	push!(nlp.op, args...)
+	return nlp
+end
+
+# not implemented: hess_coord, hess, hprod!

--- a/src/qn_model.jl
+++ b/src/qn_model.jl
@@ -41,10 +41,14 @@ function reset!(nlp :: QuasiNewtonModel)
 end
 
 # the following methods are not affected by the Hessian approximation
-for meth in (:obj, :grad, :grad!, :cons, :cons!, :jac_coord, :jac, :jprod, :jprod!, :jtprod, :jtprod!)
-  @eval begin
-    $meth(nlp :: QuasiNewtonModel, args...) = $meth(nlp.model, args...)
-  end
+for meth in (:obj, :grad, :cons, :jac_coord, :jac)
+  @eval $meth(nlp :: QuasiNewtonModel, x :: AbstractVector) = $meth(nlp.model, x)
+end
+for meth in (:grad!, :cons!, :jprod, :jtprod)
+  @eval $meth(nlp :: QuasiNewtonModel, x :: AbstractVector, y :: AbstractVector) = $meth(nlp.model, x, y)
+end
+for meth in (:jprod!, :jtprod!)
+  @eval $meth(nlp :: QuasiNewtonModel, x :: AbstractVector, y :: AbstractVector, z :: AbstractVector) = $meth(nlp.model, x, y, z)
 end
 
 # the following methods are affected by the Hessian approximation

--- a/src/qn_model.jl
+++ b/src/qn_model.jl
@@ -1,9 +1,4 @@
-export QuasiNewtonModel, LBFGSModel, LSR1Model,
-       reset!,
-       obj, grad, grad!,
-       cons, cons!, jac_coord, jac, jprod, jprod!, jtprod, jtprod!,
-       hprod, hess_op,
-       push!
+export QuasiNewtonModel, LBFGSModel, LSR1Model
 
 abstract QuasiNewtonModel <: AbstractNLPModel
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ reset!(model)
 @test_throws(NotImplementedError, jth_con(model, model.meta.x0, 1))
 
 include("test_slack_model.jl")
+include("test_qn_model.jl")
 
 @printf("For tests to pass, all models must have been written identically.\n")
 @printf("Constraints, if any, must have been declared in the same order.\n")

--- a/test/test_qn_model.jl
+++ b/test/test_qn_model.jl
@@ -1,0 +1,59 @@
+using LinearOperators
+
+function check_qn_model(qnmodel)
+
+  model = qnmodel.model
+  @assert typeof(qnmodel) <: NLPModels.QuasiNewtonModel
+  @assert qnmodel.meta.nvar == model.meta.nvar
+  @assert qnmodel.meta.ncon == model.meta.ncon
+
+  x = rand(qnmodel.meta.nvar)
+
+  @assert obj(model, x) == obj(qnmodel, x)
+  @assert neval_obj(model) == 2
+
+  @assert grad(model, x) == grad(qnmodel, x)
+  @assert neval_grad(model) == 2
+
+  @assert cons(model, x) == cons(qnmodel, x)
+  @assert neval_cons(model) == 2
+
+  @assert jac(model, x) == jac(qnmodel, x)
+  @assert neval_jac(model) == 2
+
+  v = rand(qnmodel.meta.nvar)
+  u = rand(qnmodel.meta.ncon)
+
+  @assert jprod(model, x, v) == jprod(qnmodel, x, v)
+  @assert neval_jprod(model) == 2
+
+  @assert jtprod(model, x, u) == jtprod(qnmodel, x, u)
+  @assert neval_jtprod(model) == 2
+
+  H = hess_op(qnmodel, x)
+  @assert typeof(H) <: LinearOperators.AbstractLinearOperator
+  @assert size(H) == (model.meta.nvar, model.meta.nvar)
+  @assert H * v == hprod(qnmodel, x, v)
+
+  g = grad(qnmodel, x)
+  gp = grad(qnmodel, x - g)
+  push!(qnmodel, -g, gp - g)  # only testing that the call succeeds, not that the update is valid
+  # the quasi-Newton operator itself is tested in LinearOperators
+
+  reset!(qnmodel)
+end
+
+for problem in [:hs10, :hs11, :hs14, :hs15]
+  problem_s = string(problem)
+  include("$problem_s.jl")
+  problem_f = eval(problem)
+  nlp_jump = JuMPNLPModel(problem_f())
+  @printf("Checking LBFGS formulation of %-8s\t", problem_s)
+  qn_model = LBFGSModel(nlp_jump)
+  check_qn_model(qn_model)
+  @printf("✓\n")
+  @printf("Checking LSR1 formulation of %-8s\t", problem_s)
+  qn_model = LSR1Model(nlp_jump)
+  check_qn_model(qn_model)
+  @printf("✓\n")
+end

--- a/test/test_qn_model.jl
+++ b/test/test_qn_model.jl
@@ -45,7 +45,7 @@ end
 
 for problem in [:hs10, :hs11, :hs14, :hs15]
   problem_s = string(problem)
-  include("$problem_s.jl")
+  isdefined(problem) || include("$problem_s.jl")
   problem_f = eval(problem)
   nlp_jump = JuMPNLPModel(problem_f())
   @printf("Checking LBFGS formulation of %-8s\t", problem_s)

--- a/test/test_qn_model.jl
+++ b/test/test_qn_model.jl
@@ -47,7 +47,7 @@ for problem in [:hs10, :hs11, :hs14, :hs15]
   problem_s = string(problem)
   isdefined(problem) || include("$problem_s.jl")
   problem_f = eval(problem)
-  nlp_jump = JuMPNLPModel(problem_f())
+  nlp_jump = MathProgNLPModel(problem_f())
   @printf("Checking LBFGS formulation of %-8s\t", problem_s)
   qn_model = LBFGSModel(nlp_jump)
   check_qn_model(qn_model)


### PR DESCRIPTION
A simple initial design for quasi-Newton models. Example
```julia
julia> using NLPModels
julia> model = SimpleNLPModel(x -> dot(x, x), zeros(2))
julia> qnmodel = LBFGSModel(model)  # or LSR1Model; optional memory argument
```
Differences with other types of models:
* `hess_coord()` is not implemented (the Hessian is typically dense)
* `hess()` ~~returns a `LinearOperator`~~ is not implemented
* `hprod()` applies the linear operator

I'll add tests when we agree on the design.

@abelsiqueira 
