### PR TITLE
Factor out JuMP

### DIFF
--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -13,7 +13,7 @@ export reset!,
        jth_hprod, jth_hprod!, ghjvprod, ghjvprod!,
        hess_coord, hess, hprod, hprod!, hess_op,
        varscale, lagscale, conscale,
-       NLPtoMPB, NotImplementedError
+       NotImplementedError
 
 
 include("nlp_utils.jl");
@@ -223,17 +223,9 @@ lagscale(nlp :: AbstractNLPModel, args...; kwargs...) =
 conscale(nlp :: AbstractNLPModel, args...; kwargs...) =
   throw(NotImplementedError("conscale"))
 
-"""`mp = NLPtoMPB(nlp, solver)`
-
-Return a `MathProgBase` model corresponding to this model.
-`solver` should be a solver instance, e.g., `IpoptSolver()`.
-Currently, all models are treated as nonlinear models.
-"""
-NLPtoMPB(nlp :: AbstractNLPModel, args...; kwargs...) =
-  throw(NotImplementedError("NLPtoMPB"))
-
 if Pkg.installed("MathProgBase") != nothing
   include("mpb_model.jl")
+  include("nlp_to_mpb.jl")
 end
 if Pkg.installed("JuMP") != nothing
   include("jump_model.jl")

--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -232,6 +232,9 @@ Currently, all models are treated as nonlinear models.
 NLPtoMPB(nlp :: AbstractNLPModel, args...; kwargs...) =
   throw(NotImplementedError("NLPtoMPB"))
 
+if Pkg.installed("MathProgBase") != nothing
+  include("mpb_model.jl")
+end
 if Pkg.installed("JuMP") != nothing
   include("jump_model.jl")
 end

--- a/src/jump_model.jl
+++ b/src/jump_model.jl
@@ -1,0 +1,9 @@
+import JuMP
+
+"Construct a `MathProgNLPModel` from a JuMP `Model`."
+function MathProgNLPModel(jmodel :: JuMP.Model; kwargs...)
+  JuMP.EnableNLPResolve()
+  JuMP.setsolver(jmodel, ModelReader())
+  jmodel.internalModelLoaded || JuMP.build(jmodel)
+  return MathProgNLPModel(jmodel.internalModel; kwargs...)
+end

--- a/src/mpb_model.jl
+++ b/src/mpb_model.jl
@@ -82,8 +82,8 @@ function MathProgNLPModel(mpmodel :: MathProgModel; name :: AbstractString="Gene
   lvar = mpmodel.lvar
   uvar = mpmodel.uvar
 
-  nlin = MathProgBase.numlinconstr(mpmodel)       # Number of linear constraints.
-  nquad = MathProgBase.numquadconstr(mpmodel)     # Number of quadratic constraints.
+  nlin = length(mpmodel.eval.m.linconstr)         # Number of linear constraints.
+  nquad = length(mpmodel.eval.m.quadconstr)       # Number of quadratic constraints.
   nnln = length(mpmodel.eval.m.nlpdata.nlconstr)  # Number of nonlinear constraints.
   ncon = mpmodel.numConstr                        # Total number of constraints.
   lcon = mpmodel.lcon

--- a/src/nlp_to_mpb.jl
+++ b/src/nlp_to_mpb.jl
@@ -1,0 +1,35 @@
+# Convert an AbstractNLPModel to a MathProgBase model that can be passed
+# to a standard solver.
+
+export NLPtoMPB
+
+
+"""
+    mp = NLPtoMPB(nlp, solver)
+
+Return a `MathProgBase` model corresponding to an `AbstractNLPModel`.
+
+#### Arguments
+- `nlp::AbstractNLPModel`
+- `solver::AbstractMathProgSolver` a solver instance, e.g., `IpoptSolver()`
+
+Currently, all models are treated as nonlinear models.
+
+#### Return values
+The function returns a `MathProgBase` model `mpbmodel` such that it should
+be possible to call
+
+    MathProgBase.optimize!(mpbmodel)
+"""
+NLPtoMPB(model :: AbstractNLPModel, args...) = throw(NotImplementedError("NLPtoMPB"))
+
+function NLPtoMPB(model :: MathProgNLPModel, solver :: MathProgBase.AbstractMathProgSolver)
+  mpbmodel = MathProgBase.NonlinearModel(solver)
+  MathProgBase.loadproblem!(mpbmodel,
+                            model.meta.nvar, model.meta.ncon,
+                            model.meta.lvar, model.meta.uvar,
+                            model.meta.lcon, model.meta.ucon,
+                            :Min, model.mpmodel.eval)
+  MathProgBase.setwarmstart!(mpbmodel, model.meta.x0)
+  return mpbmodel
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
 JuMP
-MathProgBase
 Ipopt

--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -220,9 +220,9 @@ function consistency(problem :: Symbol; nloops=100, rtol=1.0e-8)
   @printf("Checking problem %-15s%12s\t", problem_s, "")
   problem_f = eval(problem)
   nlp_autodiff = eval(parse("$(problem)_autodiff"))()
-  nlp_jump = JuMPNLPModel(problem_f())
+  nlp_mpb = MathProgNLPModel(problem_f())
   nlp_simple = eval(parse("$(problem)_simple"))()
-  nlps = [nlp_autodiff; nlp_jump; nlp_simple]
+  nlps = [nlp_autodiff; nlp_mpb; nlp_simple]
 
   consistent_nlps(nlps, nloops=nloops, rtol=rtol)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,8 @@ for meth in filter(f -> isa(eval(f), Function), names(NLPModels))
   @test_throws(NotImplementedError, meth(model))
 end
 
-model = JuMPNLPModel(genrose(), name="genrose")
+include("genrose.jl")
+model = MathProgNLPModel(genrose(), name="genrose")
 @assert model.meta.name == "genrose"
 for counter in fieldnames(model.counters)
   @eval @assert $counter(model) == 0
@@ -45,4 +46,3 @@ include("test_mpb.jl")
 
 include("test_autodiff_model.jl")
 include("test_simple_model.jl")
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ for problem in [:brownden, :hs5, :hs6, :hs10, :hs11, :hs14]
   consistency(problem)
 end
 
-# include("test_mpb.jl")
+include("test_mpb.jl")
 
 include("test_autodiff_model.jl")
 include("test_simple_model.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ for problem in [:brownden, :hs5, :hs6, :hs10, :hs11, :hs14]
   consistency(problem)
 end
 
-include("test_mpb.jl")
+# include("test_mpb.jl")
 
 include("test_autodiff_model.jl")
 include("test_simple_model.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,6 @@ for meth in filter(f -> isa(eval(f), Function), names(NLPModels))
   @test_throws(NotImplementedError, meth(model))
 end
 
-include("genrose.jl")
 model = MathProgNLPModel(genrose(), name="genrose")
 @assert model.meta.name == "genrose"
 for counter in fieldnames(model.counters)

--- a/test/test_mpb.jl
+++ b/test/test_mpb.jl
@@ -1,8 +1,6 @@
 using Ipopt
 using JuMP
 
-include("hs6.jl")
-
 # pass an AmplModel to IPOPT
 nlp = MathProgNLPModel(hs6())
 show(nlp.meta)

--- a/test/test_mpb.jl
+++ b/test/test_mpb.jl
@@ -1,4 +1,10 @@
-nlp = JuMPNLPModel(hs6())
+using Ipopt
+using JuMP
+
+include("hs6.jl")
+
+# pass an AmplModel to IPOPT
+nlp = MathProgNLPModel(hs6())
 show(nlp.meta)
 print(nlp.meta)
 model = NLPtoMPB(nlp, IpoptSolver())

--- a/test/test_slack_model.jl
+++ b/test/test_slack_model.jl
@@ -1,20 +1,20 @@
 # an unconstrained problem should be returned unchanged
 @printf("Checking slack formulation of genrose\t")
-model = JuMPNLPModel(genrose())
+model = MathProgNLPModel(genrose())
 smodel = SlackModel(model)
 @assert smodel == model
 @printf("✓\n")
 
 # a bound-constrained problem should be returned unchanged
 @printf("Checking slack formulation of hs5\t")
-model = JuMPNLPModel(hs5())
+model = MathProgNLPModel(hs5())
 smodel = SlackModel(model)
 @assert smodel == model
 @printf("✓\n")
 
 # an equality-constrained problem should be returned unchanged
 @printf("Checking slack formulation of hs6\t")
-model = JuMPNLPModel(hs6())
+model = MathProgNLPModel(hs6())
 smodel = SlackModel(model)
 @assert smodel == model
 @printf("✓\n")
@@ -106,7 +106,7 @@ for problem in [:hs10, :hs11, :hs14, :hs15]
   problem_s = string(problem)
   @printf("Checking slack formulation of %-8s\t", problem_s)
   problem_f = eval(problem)
-  nlp_jump = JuMPNLPModel(problem_f())
+  nlp_jump = MathProgNLPModel(problem_f())
   slack_model = SlackModel(nlp_jump)
   check_slack_model(slack_model)
   @printf("✓\n")


### PR DESCRIPTION
`JuMPNLPModel` is now called `MathProgNLPModel` since JuMP is not strictly required. It is still possible to create a `MathProgNLPModel` from a `JuMP.Model`, and that's indeed the current way to create one.

The IPOPT test now seems irrelevant to this package.