### PR TITLE
Optional check_derivatives on consistent_nlps and qualify reset! as NLPModels.reset!

### DIFF
--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -195,23 +195,25 @@ function consistent_functions(nlps; nloops=100, rtol=1.0e-8)
 
 end
 
-function consistent_nlps(nlps; nloops=100, rtol=1.0e-8)
+function consistent_nlps(nlps; nloops=100, rtol=1.0e-8, check_derivatives=true)
   consistent_counters(nlps)
   consistent_meta(nlps, rtol=rtol)
   consistent_functions(nlps, nloops=nloops, rtol=rtol)
   consistent_counters(nlps)
   for nlp in nlps
-    reset!(nlp)
+    NLPModels.reset!(nlp)
   end
   consistent_counters(nlps)
   @printf("✓%15s", " ")
-  for nlp in nlps
-    @assert length(gradient_check(nlp)) == 0
-    @assert length(jacobian_check(nlp)) == 0
-    @assert sum(map(length, values(hessian_check(nlp)))) == 0
-    @assert sum(map(length, values(hessian_check_from_grad(nlp)))) == 0
+  if check_derivatives
+    for nlp in nlps
+      @assert length(gradient_check(nlp)) == 0
+      @assert length(jacobian_check(nlp)) == 0
+      @assert sum(map(length, values(hessian_check(nlp)))) == 0
+      @assert sum(map(length, values(hessian_check_from_grad(nlp)))) == 0
+    end
+    @printf("✓%18s", " ")
   end
-  @printf("✓%18s", " ")
 
   # If there are inequalities, test the SlackModels of each of these models
   if nlps[1].meta.ncon > length(nlps[1].meta.jfix)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ end
 obj(model, model.meta.x0)
 @assert neval_obj(model) == 1
 
-reset!(model)
+NLPModels.reset!(model)
 @assert neval_obj(model) == 0
 
 @test_throws(NotImplementedError, jth_con(model, model.meta.x0, 1))

--- a/test/test_slack_model.jl
+++ b/test/test_slack_model.jl
@@ -99,7 +99,7 @@ function check_slack_model(smodel)
   jtu = zeros(N)
   @assert all(jtprod!(smodel, x, u, jtu) == Jtu)
 
-  reset!(smodel)
+  NLPModels.reset!(smodel)
 end
 
 for problem in [:hs10, :hs11, :hs14, :hs15]


### PR DESCRIPTION
I got errors on `reset!` that weren't happening before AFAIR. Don't know why, but they are qualified now.

https://github.com/JuliaSmoothOptimizers/AmplNLReader.jl/pull/29