### PR TITLE
use evaluator that allows us to count evals

### DIFF
--- a/src/nlp_to_mpb.jl
+++ b/src/nlp_to_mpb.jl
@@ -152,7 +152,7 @@ function NLPtoMPB(model :: MathProgNLPModel, solver :: MathProgBase.AbstractMath
                             model.meta.lvar, model.meta.uvar,
                             model.meta.lcon, model.meta.ucon,
                             model.meta.minimize ? :Min : :Max,
-                            model.mpmodel.eval)
+                            NLPModelEvaluator(model))
   MathProgBase.setwarmstart!(mpbmodel, model.meta.x0)
   return mpbmodel
 end


### PR DESCRIPTION
This simple change allows us to retrieve evaluation counters from a `AbstractNLPModel` after calling a `MathProgBase` solver. It should have been this way since the beginning.