### PR TITLE
Last working version of LinearOperators is 0.3.1

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-LinearOperators 0.2.0
+LinearOperators 0.2.0 0.4.0


### PR DESCRIPTION
For a last release before #111, which requires `LinearOperators 0.4.0`.