### PR TITLE
Slack remodel

### DIFF
--- a/src/autodiff_nlsmodel.jl
+++ b/src/autodiff_nlsmodel.jl
@@ -57,7 +57,7 @@ ADNLSModel(F :: Function, n :: Int, m :: Int; kwargs...) = ADNLSModel(F, zeros(n
 
 function residual!(nls :: ADNLSModel, x :: AbstractVector, Fx :: AbstractVector)
   increment!(nls, :neval_residual)
-  Fx[:] = nls.F(x)
+  Fx[1:nls.nls_meta.nequ] = nls.F(x)
   return Fx
 end
 
@@ -68,13 +68,13 @@ end
 
 function jprod_residual!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
   increment!(nls, :neval_jprod_residual)
-  Jv[:] = ForwardDiff.jacobian(nls.F, x) * v
+  Jv[1:nls.nls_meta.nequ] = ForwardDiff.jacobian(nls.F, x) * v
   return Jv
 end
 
 function jtprod_residual!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
   increment!(nls, :neval_jtprod_residual)
-  Jtv[:] = ForwardDiff.jacobian(nls.F, x)' * v
+  Jtv[1:nls.meta.nvar] = ForwardDiff.jacobian(nls.F, x)' * v
   return Jtv
 end
 
@@ -85,7 +85,7 @@ end
 
 function hprod_residual!(nls :: ADNLSModel, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
   increment!(nls, :neval_hprod_residual)
-  Hiv[:] = ForwardDiff.hessian(x->nls.F(x)[i], x) * v
+  Hiv[1:nls.meta.nvar] = ForwardDiff.hessian(x->nls.F(x)[i], x) * v
   return Hiv
 end
 

--- a/src/lls_model.jl
+++ b/src/lls_model.jl
@@ -45,7 +45,7 @@ end
 
 function residual!(nls :: LLSModel, x :: AbstractVector, Fx :: AbstractVector)
   increment!(nls, :neval_residual)
-  Fx[:] = nls.A * x - nls.b
+  Fx[1:nls.nls_meta.nequ] = nls.A * x - nls.b
   return Fx
 end
 
@@ -60,13 +60,13 @@ end
 
 function jprod_residual!(nls :: LLSModel, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
   increment!(nls, :neval_jprod_residual)
-  Jv[:] = nls.A * v
+  Jv[1:nls.nls_meta.nequ] = nls.A * v
   return Jv
 end
 
 function jtprod_residual!(nls :: LLSModel, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
   increment!(nls, :neval_jtprod_residual)
-  Jtv[:] = nls.A' * v
+  Jtv[1:nls.meta.nvar] = nls.A' * v
   return Jtv
 end
 

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -81,7 +81,10 @@ function SlackModel(nlp :: AbstractNLPModel)
 
   meta = slack_meta(nlp.meta)
 
-  return SlackModel(meta, NLSMeta(0, 0), nlp)
+  snlp = SlackModel(meta, NLSMeta(0, 0), nlp)
+  finalizer(nlp -> finalize(nlp.model), snlp)
+
+  return snlp
 end
 
 function SlackModel(nls :: AbstractNLSModel)
@@ -93,7 +96,10 @@ function SlackModel(nls :: AbstractNLSModel)
                      nls.meta.nvar + ns,
                      [nls.meta.x0; zeros(ns)])
 
-  return SlackModel(meta, nls_meta, nls)
+  snls = SlackModel(meta, nls_meta, nls)
+  finalizer(nls -> finalize(nls.model), snls)
+
+  return snls
 end
 
 import Base.show

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -335,12 +335,11 @@ end
 function hess_residual(nlp :: SlackModel, x :: AbstractVector, i :: Int)
   n = nlp.model.meta.nvar
   ns = nlp.meta.nvar - n
-  ne = nlp.nls_meta.nequ
   Hx = hess_residual(nlp.model, x[1:n], i)
   if issparse(Hx)
-    return [Hx spzeros(ne, ns); spzeros(ns, ne + ns)]
+    return [Hx spzeros(n, ns); spzeros(ns, n + ns)]
   else
-    return [Hx zeros(ne, ns); zeros(ns, ne + ns)]
+    return [Hx zeros(n, ns); zeros(ns, n + ns)]
   end
 end
 

--- a/test/nls_consistency.jl
+++ b/test/nls_consistency.jl
@@ -277,6 +277,35 @@ function consistent_nls()
     consistent_functions(nlss, nloops=10)
   end
 
+  @testset "Consistency of slack variant" begin
+    F(x) = [x[1] - 1.0;
+            x[2] - x[1]^2;
+            sin(x[1] * x[2]) * x[3]]
+    x0 = [0.3; 0.4; 0.5]
+    c(x) = [x[1]^2 - x[2]^2;
+            2 * x[1] * x[2];
+            x[1] + x[2];
+            cos(x[1]) - x[2]]
+    lcon = [0.0; -1.0; -Inf; 0.0]
+    ucon = [Inf;  1.0;  0.0; 0.0]
+    nls = ADNLSModel(F, x0, 3, c=c, lcon=lcon, ucon=ucon)
+
+    nls_manual_slack = ADNLSModel(F, [x0; zeros(3)], 3,
+                                  c=x->c(x) - [x[4]; x[6]; x[5]; 0.0],
+                                  lcon=zeros(4), ucon=zeros(4),
+                                  lvar=[-Inf; -Inf; -Inf; 0.0; -Inf; -1.0],
+                                  uvar=[Inf; Inf; Inf; Inf; 0.0; 1.0])
+
+    nls_auto_slack = SlackModel(nls)
+    nlss = [nls_manual_slack, nls_auto_slack]
+    consistent_nls_counters(nlss)
+    consistent_counters(nlss)
+    consistent_nls_functions(nlss)
+    consistent_nls_counters(nlss)
+    consistent_counters(nlss)
+    consistent_functions(nlss, nloops=10)
+  end
+
 end
 
 consistent_nls()

--- a/test/nls_consistency.jl
+++ b/test/nls_consistency.jl
@@ -325,7 +325,6 @@ function consistent_nls()
     ucon = [Inf;  1.0;  0.0; 0.0]
     adnls = ADNLSModel(x -> A*x - b, x0, 3, c=x -> C*x, lcon=lcon, ucon=ucon)
     lls = LLSModel(A, b, x0=x0, C=C, lcon=lcon, ucon=ucon)
-    lls2 = LLSModel(A, b, x0=x0, C=C, lcon=lcon, ucon=ucon)
 
     nlss = [SlackModel(adnls), SlackModel(lls)]
     consistent_nls_counters(nlss)
@@ -342,6 +341,7 @@ function consistent_nls()
     b = rand(m)
     lls = LLSModel(A, b)
     lls2 = LLSModel(LinearOperator(A), b)
+    lls3 = LLSModel(sparse(A), b)
     nlss = [lls, lls2]
     consistent_nls_counters(nlss)
     consistent_counters(nlss)
@@ -357,9 +357,14 @@ function consistent_nls()
     lcon, ucon = lcon[I], ucon[I]
     lls  = LLSModel(A, b, C=C, lcon=lcon, ucon=ucon)
     lls2 = LLSModel(LinearOperator(A), b, C=C, lcon=lcon, ucon=ucon)
-    lls3 = LLSModel(A, b, C=LinearOperator(C), lcon=lcon, ucon=ucon)
-    lls4 = LLSModel(LinearOperator(A), b, C=LinearOperator(C), lcon=lcon, ucon=ucon)
-    nlss = [lls, lls2, lls3, lls4]
+    lls3 = LLSModel(sparse(A), b, C=C, lcon=lcon, ucon=ucon)
+    lls4 = LLSModel(A, b, C=LinearOperator(C), lcon=lcon, ucon=ucon)
+    lls5 = LLSModel(LinearOperator(A), b, C=LinearOperator(C), lcon=lcon, ucon=ucon)
+    lls6 = LLSModel(sparse(A), b, C=LinearOperator(C), lcon=lcon, ucon=ucon)
+    lls7 = LLSModel(A, b, C=C, lcon=lcon, ucon=ucon)
+    lls8 = LLSModel(LinearOperator(A), b, C=sparse(C), lcon=lcon, ucon=ucon)
+    lls9 = LLSModel(sparse(A), b, C=sparse(C), lcon=lcon, ucon=ucon)
+    nlss = [lls, lls2, lls3, lls4, lls5, lls6, lls7, lls8, lls9]
     consistent_nls_counters(nlss)
     consistent_counters(nlss)
     consistent_nls_functions(nlss, exclude=[jac_residual])

--- a/test/nls_consistency.jl
+++ b/test/nls_consistency.jl
@@ -306,6 +306,25 @@ function consistent_nls()
     consistent_functions(nlss, nloops=10)
   end
 
+  @testset "Consistency of slack variant for linear problem" begin
+    A = [1.0 0.0; 1.0 2.0; 2.0 1.0]
+    b = [1.0; 3.0; 2.0]
+    C = [1.0 1.0; 1.0 -1.0; 2.0 1.0; 1.0 2.0]
+    x0 = ones(2)
+    lcon = [0.0; -1.0; -Inf; 0.0]
+    ucon = [Inf;  1.0;  0.0; 0.0]
+    adnls = ADNLSModel(x -> A*x - b, x0, 3, c=x -> C*x, lcon=lcon, ucon=ucon)
+    lls = LLSModel(A, b, x0=x0, C=C, lcon=lcon, ucon=ucon)
+
+    nlss = [SlackModel(adnls), SlackModel(lls)]
+    consistent_nls_counters(nlss)
+    consistent_counters(nlss)
+    consistent_nls_functions(nlss)
+    consistent_nls_counters(nlss)
+    consistent_counters(nlss)
+    consistent_functions(nlss, nloops=10)
+  end
+
 end
 
 consistent_nls()

--- a/test/test_feasibility_nls_model.jl
+++ b/test/test_feasibility_nls_model.jl
@@ -5,6 +5,18 @@ function feasibility_nls_test()
     nls = FeasibilityResidual(nlp)
 
     @test isapprox(residual(nls, ones(2)), zeros(2), rtol=1e-8)
+
+    nlp = ADNLPModel(x->0, zeros(2), c=x->[x[1] - 1; x[2] - x[1]^2],
+                     lvar=[-0.3; -0.5], uvar=[1.2; 3.4],
+                     lcon=-ones(2), ucon=2*ones(2))
+    nls = FeasibilityResidual(nlp)
+
+    @test nls.meta.nvar == 4
+    @test nls.nls_meta.nequ == 2
+    @test nls.meta.lvar == [-0.3; -0.5; -1.0; -1.0]
+    @test nls.meta.uvar == [ 1.2;  3.4;  2.0;  2.0]
+    @test isapprox(residual(nls, [1.0; 1.0; 0.0; 0.0]), zeros(2), rtol=1e-8)
+    @test isapprox(residual(nls, [0.0; 1.0; 2.0; 3.0]), [-3.0; -2.0], rtol=1e-8)
   end
 end
 

--- a/test/test_slack_model.jl
+++ b/test/test_slack_model.jl
@@ -104,9 +104,9 @@ end
 
 for problem in ["hs10", "hs11", "hs14"]
   @printf("Checking slack formulation of %-8s\t", problem)
-  problem_f = eval(Symbol(problem * "_autodiff"))
+  problem_f = eval(Symbol(problem * "_simple"))
   nlp = problem_f()
-  slack_model = ConvertToSlackModel(nlp)
+  slack_model = SlackModel(nlp)
   check_slack_model(slack_model)
   @printf("✓\n")
 end

--- a/test/test_slack_model.jl
+++ b/test/test_slack_model.jl
@@ -106,7 +106,7 @@ for problem in ["hs10", "hs11", "hs14"]
   @printf("Checking slack formulation of %-8s\t", problem)
   problem_f = eval(Symbol(problem * "_autodiff"))
   nlp = problem_f()
-  slack_model = SlackModel(nlp)
+  slack_model = ConvertToSlackModel(nlp)
   check_slack_model(slack_model)
   @printf("✓\n")
 end


### PR DESCRIPTION
Built on top of #115, please review only the last commit.

This adds `SlackModel(::ADNLPModel)` which returns `ADNLPModel`.