### PR TITLE
Create new hess_residual which computes sum of Hessians

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -57,7 +57,7 @@ and its derivatives. Namely,
 |---------------------|---|
 | ``F(x)``            | [`residual`](@ref), [`residual!`](@ref) |
 | ``J_F(x)``          | [`jac_residual`](@ref), [`jprod_residual`](@ref), [`jprod_residual!`](@ref), [`jtprod_residual`](@ref), [`jtprod_residual!`](@ref), [`jac_op_residual`](@ref), [`jac_op_residual!`](@ref) |
-| ``\nabla^2 F_i(x)`` | [`hess_residual`](@ref), [`hprod_residual`](@ref), [`hprod_residual!`](@ref), [`hess_op_residual`](@ref), [`hess_op_residual!`](@ref) |
+| ``\nabla^2 F_i(x)`` | [`hess_residual`](@ref), [`jth_hess_residual`](@ref), [`hprod_residual`](@ref), [`hprod_residual!`](@ref), [`hess_op_residual`](@ref), [`hess_op_residual!`](@ref) |
 
 
 ## AbstractNLPModel functions
@@ -103,6 +103,7 @@ jtprod_residual!
 jac_op_residual
 jac_op_residual!
 hess_residual
+jth_hess_residual
 hprod_residual
 hprod_residual!
 hess_op_residual

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -36,7 +36,8 @@ least squares models.
 | [`neval_jac_residual`](@ref)    | Jacobian of the residual |
 | [`neval_jprod_residual`](@ref)  | Product of Jacobian of residual and vector |
 | [`neval_jtprod_residual`](@ref) | Product of transposed Jacobian of residual and vector |
-| [`neval_hess_residual`](@ref)   | Hessian of a residual component |
+| [`neval_hess_residual`](@ref)   | Sum of Hessians of residuals |
+| [`neval_jhess_residual`](@ref)  | Hessian of a residual component |
 | [`neval_hprod_residual`](@ref)  | Product of Hessian of a residual component and vector |
 
 To get the sum of all counters called for a problem, use
@@ -84,6 +85,7 @@ neval_jac_residual
 neval_jprod_residual
 neval_jtprod_residual
 neval_hess_residual
+neval_jhess_residual
 neval_hprod_residual
 sum_counters
 bound_constrained

--- a/src/NLSModels.jl
+++ b/src/NLSModels.jl
@@ -184,7 +184,7 @@ function jac_op_residual!(nls :: AbstractNLSModel, x :: AbstractVector,
 end
 
 """
-    Hi = hess_residual(nls, x, v)
+    H = hess_residual(nls, x, v)
 
 Computes the linear combinations of the Hessians of the residuals at x with coefficients
 `v`.
@@ -194,9 +194,9 @@ function hess_residual(nls :: AbstractNLSModel, x :: AbstractVector, v :: Abstra
 end
 
 """
-    Hi = jth_hess_residual(nls, x, i)
+    Hj = jth_hess_residual(nls, x, j)
 
-Computes the Hessian of the i-th residual at x.
+Computes the Hessian of the j-th residual at x.
 """
 function jth_hess_residual(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int)
   throw(NotImplementedError("jth_hess_residual"))

--- a/src/feasibility_form_nls.jl
+++ b/src/feasibility_form_nls.jl
@@ -183,9 +183,7 @@ function hess(nlp :: FeasibilityFormNLS, xr :: AbstractVector;
   n, m, ne = nlp.internal.meta.nvar, nlp.internal.meta.ncon, nlp.internal.nls_meta.nequ
   x = @view xr[1:n]
   @views Hx = m > 0 ? hess(nlp.internal, x, obj_weight=0.0, y=y[ne+1:end]) : spzeros(n, n)
-  for i = 1:ne
-    Hx += hess_residual(nlp.internal, x, i) * y[i]
-  end
+  Hx += hess_residual(nlp.internal, x, @view y[1:ne])
   return [Hx spzeros(n, ne); spzeros(ne, n) obj_weight * I]
 end
 
@@ -240,8 +238,14 @@ function jtprod_residual!(nlp :: FeasibilityFormNLS, x :: AbstractVector, v :: A
   return Jtv
 end
 
-function hess_residual(nlp :: FeasibilityFormNLS, x :: AbstractVector, i :: Int)
+function hess_residual(nlp :: FeasibilityFormNLS, x :: AbstractVector, v :: AbstractVector)
   increment!(nlp, :neval_hess_residual)
+  n = nlp.meta.nvar
+  return spzeros(n, n)
+end
+
+function jth_hess_residual(nlp :: FeasibilityFormNLS, x :: AbstractVector, i :: Int)
+  increment!(nlp, :neval_jhess_residual)
   n = nlp.meta.nvar
   return spzeros(n, n)
 end

--- a/src/feasibility_residual.jl
+++ b/src/feasibility_residual.jl
@@ -78,8 +78,13 @@ function jtprod_residual!(nls :: FeasibilityResidual, x :: AbstractVector, v :: 
   return jtprod!(nls.nlp, x, v, Jtv)
 end
 
-function hess_residual(nls :: FeasibilityResidual, x :: AbstractVector, i :: Int)
+function hess_residual(nls :: FeasibilityResidual, x :: AbstractVector, v :: AbstractVector)
   increment!(nls, :neval_hess_residual)
+  return hess(nls.nlp, x, obj_weight = 0.0, y=v)
+end
+
+function jth_hess_residual(nls :: FeasibilityResidual, x :: AbstractVector, i :: Int)
+  increment!(nls, :neval_jhess_residual)
   y = zeros(nls.nls_meta.nequ)
   y[i] = 1.0
   return hess(nls.nlp, x, obj_weight = 0.0, y=y)

--- a/src/lls_model.jl
+++ b/src/lls_model.jl
@@ -70,8 +70,14 @@ function jtprod_residual!(nls :: LLSModel, x :: AbstractVector, v :: AbstractVec
   return Jtv
 end
 
-function hess_residual(nls :: LLSModel, x :: AbstractVector, i :: Int)
+function hess_residual(nls :: LLSModel, x :: AbstractVector, v :: AbstractVector)
   increment!(nls, :neval_hess_residual)
+  n = size(nls.A, 2)
+  return zeros(n, n)
+end
+
+function jth_hess_residual(nls :: LLSModel, x :: AbstractVector, i :: Int)
+  increment!(nls, :neval_jhess_residual)
   n = size(nls.A, 2)
   return zeros(n, n)
 end

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -353,10 +353,21 @@ function jac_op_residual!(nls :: SlackNLSModel, x :: AbstractVector,
                                                false, false, prod, nothing, ctprod)
 end
 
-function hess_residual(nlp :: SlackNLSModel, x :: AbstractVector, i :: Int)
+function hess_residual(nlp :: SlackNLSModel, x :: AbstractVector, v :: AbstractVector)
   n = nlp.model.meta.nvar
   ns = nlp.meta.nvar - n
-  Hx = hess_residual(nlp.model, view(x, 1:n), i)
+  Hx = hess_residual(nlp.model, view(x, 1:n), v)
+  if issparse(Hx)
+    return [Hx spzeros(n, ns); spzeros(ns, n + ns)]
+  else
+    return [Hx zeros(n, ns); zeros(ns, n + ns)]
+  end
+end
+
+function jth_hess_residual(nlp :: SlackNLSModel, x :: AbstractVector, i :: Int)
+  n = nlp.model.meta.nvar
+  ns = nlp.meta.nvar - n
+  Hx = jth_hess_residual(nlp.model, view(x, 1:n), i)
   if issparse(Hx)
     return [Hx spzeros(n, ns); spzeros(ns, n + ns)]
   else

--- a/test/test_generic_coord.jl
+++ b/test/test_generic_coord.jl
@@ -45,12 +45,8 @@ function NLPModels.jac_residual(nlp :: TestGenericCoordNLSModel, x :: AbstractVe
   return [1.0 0.0; -20x[1] 10.0]
 end
 
-function NLPModels.hess_residual(nlp :: TestGenericCoordNLSModel, x :: AbstractVector, i :: Int)
-  if i == 1
-    return zeros(2, 2)
-  else
-    return [-20.0 0; 0 0]
-  end
+function NLPModels.hess_residual(nlp :: TestGenericCoordNLSModel, x :: AbstractVector, v :: AbstractVector)
+  return [-20.0 0; 0 0] * v[2]
 end
 
 

--- a/test/test_lls_model.jl
+++ b/test/test_lls_model.jl
@@ -9,8 +9,9 @@ function lls_test()
 
       @test isapprox(A * x - b, residual(nls, x), rtol=1e-8)
       @test A == jac_residual(nls, x)
+      @test hess_residual(nls, x, ones(10)) == zeros(3,3)
       for i = 1:10
-        @test isapprox(zeros(3, 3), hess_residual(nls, x, i), rtol=1e-8)
+        @test isapprox(zeros(3, 3), jth_hess_residual(nls, x, i), rtol=1e-8)
       end
 
       I, J, V = jac_coord(nls, x)

--- a/test/test_nlsmodels.jl
+++ b/test/test_nlsmodels.jl
@@ -8,7 +8,8 @@ model = DummyNLSModel()
 for mtd in [:jprod_residual!, :jtprod_residual!]
   @eval @test_throws(NotImplementedError, $mtd(model, [0], [1], [2]))
 end
-@test_throws(NotImplementedError, hess_residual(model, [0], 1))
+@test_throws(NotImplementedError, hess_residual(model, [0], [1]))
+@test_throws(NotImplementedError, jth_hess_residual(model, [0], 1))
 @test_throws(NotImplementedError, hprod_residual!(model, [0], 1, [2], [3]))
 
 include("test_autodiff_nls_model.jl")

--- a/test/test_simple_nls_model.jl
+++ b/test/test_simple_nls_model.jl
@@ -5,7 +5,7 @@ function simple_nls_test()
       b = ones(10)
       F(x) = A * x - b
       JF(x) = A
-      nls = SimpleNLSModel(3, 10, F=F, JF=JF, Hi=(x,i)->zeros(3,3))
+      nls = SimpleNLSModel(3, 10, F=F, JF=JF, H=(x,v)->zeros(3,3), Hi=(x,i)->zeros(3,3))
 
       x = [1.0; -1.0; 1.0]
       @test isapprox(residual(nls, x), A * x - b, rtol=1e-8)

--- a/test/test_view_subarray.jl
+++ b/test/test_view_subarray.jl
@@ -174,7 +174,7 @@ function test_view_subarray_nls(nls)
       end
 
       for i = 1:ne
-        @test hess_residual(nls, x[I], i) ≈ hess_residual(nls, xv, i)
+        @test jth_hess_residual(nls, x[I], i) ≈ jth_hess_residual(nls, xv, i)
 
         for J = Vidxs, K in Vidxs
           vv = @view v[J]


### PR DESCRIPTION
New `hess_residual(nlp, x, v)` computes `\sum_{i=1}^{n_e} v_i \nabla^2 F_i(x)`, and increments `:neval_hess_residual`.
Old `hess_residual(nlp, x, i)` computes `\nabla^2 F_i(x)`, and now increments the new `:neval_ihess_residual`.