### PR TITLE
LinearOpeators now have tprod

### DIFF
--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -219,8 +219,8 @@ function jac_op(nlp :: AbstractNLPModel, x :: AbstractVector)
   ctprod = @closure v -> jtprod(nlp, x, v)
   F1 = typeof(prod)
   F3 = typeof(ctprod)
-  return LinearOperator{Float64,F1,Nothing,F3}(nlp.meta.ncon, nlp.meta.nvar,
-                                               false, false, prod, nothing, ctprod)
+  return LinearOperator{Float64,F1,F3,F3}(nlp.meta.ncon, nlp.meta.nvar,
+                                          false, false, prod, ctprod, ctprod)
 end
 
 """`J = jac_op!(nlp, x, Jv, Jtv)`
@@ -236,8 +236,8 @@ function jac_op!(nlp :: AbstractNLPModel, x :: AbstractVector,
   ctprod = @closure v -> jtprod!(nlp, x, v, Jtv)
   F1 = typeof(prod)
   F3 = typeof(ctprod)
-  return LinearOperator{Float64,F1,Nothing,F3}(nlp.meta.ncon, nlp.meta.nvar,
-                                               false, false, prod, nothing, ctprod)
+  return LinearOperator{Float64,F1,F3,F3}(nlp.meta.ncon, nlp.meta.nvar,
+                                          false, false, prod, ctprod, ctprod)
 end
 
 jth_hprod(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::Integer) =
@@ -312,8 +312,8 @@ function hess_op(nlp :: AbstractNLPModel, x :: AbstractVector;
                  obj_weight :: Float64=1.0, y :: AbstractVector=zeros(nlp.meta.ncon))
   prod = @closure v -> hprod(nlp, x, v; obj_weight=obj_weight, y=y)
   F = typeof(prod)
-  return LinearOperator{Float64,F,Nothing,Nothing}(nlp.meta.nvar, nlp.meta.nvar,
-                                                   true, true, prod, nothing, nothing)
+  return LinearOperator{Float64,F,F,F}(nlp.meta.nvar, nlp.meta.nvar,
+                                       true, true, prod, prod, prod)
 end
 
 """`H = hess_op!(nlp, x, Hv; obj_weight=1.0, y=zeros)`
@@ -332,8 +332,8 @@ function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, Hv :: AbstractVe
                  obj_weight :: Float64=1.0, y :: AbstractVector=zeros(nlp.meta.ncon))
   prod = @closure v -> hprod!(nlp, x, v, Hv; obj_weight=obj_weight, y=y)
   F = typeof(prod)
-  return LinearOperator{Float64,F,Nothing,Nothing}(nlp.meta.nvar, nlp.meta.nvar,
-                                                   true, true, prod, nothing, nothing)
+  return LinearOperator{Float64,F,F,F}(nlp.meta.nvar, nlp.meta.nvar,
+                                       true, true, prod, prod, prod)
 end
 
 push!(nlp :: AbstractNLPModel, args...; kwargs...) =

--- a/src/NLSModels.jl
+++ b/src/NLSModels.jl
@@ -173,8 +173,8 @@ function jac_op_residual(nls :: AbstractNLSModel, x :: AbstractVector)
   ctprod = @closure v -> jtprod_residual(nls, x, v)
   F1 = typeof(prod)
   F3 = typeof(ctprod)
-  return LinearOperator{Float64,F1,Nothing,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
-                                               false, false, prod, nothing, ctprod)
+  return LinearOperator{Float64,F1,F3,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+                                          false, false, prod, ctprod, ctprod)
 end
 
 """
@@ -189,8 +189,8 @@ function jac_op_residual!(nls :: AbstractNLSModel, x :: AbstractVector,
   ctprod = @closure v -> jtprod_residual!(nls, x, v, Jtv)
   F1 = typeof(prod)
   F3 = typeof(ctprod)
-  return LinearOperator{Float64,F1,Nothing,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
-                                               false, false, prod, nothing, ctprod)
+  return LinearOperator{Float64,F1,F3,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+                                          false, false, prod, ctprod, ctprod)
 end
 
 """
@@ -249,8 +249,8 @@ Computes the Hessian of the i-th residual at x, in linear operator form.
 function hess_op_residual(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int)
   prod = @closure v -> hprod_residual(nls, x, i, v)
   F = typeof(prod)
-  return LinearOperator{Float64,F,Nothing,Nothing}(nls_meta(nls).nvar, nls_meta(nls).nvar,
-                                                   true, true, prod, nothing, nothing)
+  return LinearOperator{Float64,F,F,F}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+                                       true, true, prod, prod, prod)
 end
 
 """
@@ -261,8 +261,8 @@ Computes the Hessian of the i-th residual at x, in linear operator form. The vec
 function hess_op_residual!(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int, Hiv :: AbstractVector)
   prod = @closure v -> hprod_residual!(nls, x, i, v, Hiv)
   F = typeof(prod)
-  return LinearOperator{Float64,F,Nothing,Nothing}(nls_meta(nls).nvar, nls_meta(nls).nvar,
-                                                   true, true, prod, nothing, nothing)
+  return LinearOperator{Float64,F,F,F}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+                                       true, true, prod, prod, prod)
 end
 
 function obj(nls :: AbstractNLSModel, x :: AbstractVector)

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -346,8 +346,8 @@ function jac_op_residual(nls :: SlackNLSModel, x :: AbstractVector)
   ctprod = @closure v -> jtprod_residual(nls, x, v)
   F1 = typeof(prod)
   F3 = typeof(ctprod)
-  return LinearOperator{Float64,F1,Nothing,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
-                                               false, false, prod, nothing, ctprod)
+  return LinearOperator{Float64,F1,F3,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+                                          false, false, prod, ctprod, ctprod)
 end
 
 function jac_op_residual!(nls :: SlackNLSModel, x :: AbstractVector,
@@ -356,8 +356,8 @@ function jac_op_residual!(nls :: SlackNLSModel, x :: AbstractVector,
   ctprod = @closure v -> jtprod_residual!(nls, x, v, Jtv)
   F1 = typeof(prod)
   F3 = typeof(ctprod)
-  return LinearOperator{Float64,F1,Nothing,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
-                                               false, false, prod, nothing, ctprod)
+  return LinearOperator{Float64,F1,F3,F3}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+                                          false, false, prod, ctprod, ctprod)
 end
 
 function hess_residual(nlp :: SlackNLSModel, x :: AbstractVector, v :: AbstractVector)
@@ -403,13 +403,13 @@ end
 function hess_op_residual(nls :: SlackNLSModel, x :: AbstractVector, i :: Int)
   prod = @closure v -> hprod_residual(nls, x, i, v)
   F = typeof(prod)
-  return LinearOperator{Float64,F,Nothing,Nothing}(nls_meta(nls).nvar, nls_meta(nls).nvar,
-                                                   true, true, prod, nothing, nothing)
+  return LinearOperator{Float64,F,F,F}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+                                       true, true, prod, prod, prod)
 end
 
 function hess_op_residual!(nls :: SlackNLSModel, x :: AbstractVector, i :: Int, Hiv :: AbstractVector)
   prod = @closure v -> hprod_residual!(nls, x, i, v, Hiv)
   F = typeof(prod)
-  return LinearOperator{Float64,F,Nothing,Nothing}(nls_meta(nls).nvar, nls_meta(nls).nvar,
-                                                   true, true, prod, nothing, nothing)
+  return LinearOperator{Float64,F,F,F}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+                                       true, true, prod, prod, prod)
 end


### PR DESCRIPTION
The use of `.tprod` is not directly expected, so it wasn't passed. Also did the same for `hprod`, just in case.
Closes #162 