### PR TITLE
Fix display math in docstrings.

### DIFF
--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -3,6 +3,14 @@ __precompile__()
 
 module NLPModels
 
+# For documentation purpose
+const LAGRANGIAN_HESSION = raw"""
+```math
+∇²L(x,y) = σ ∇²f(x) + ∑_i yᵢ ∇²cᵢ(x),
+```
+with σ = obj_weight
+"""
+
 using LinearAlgebra, LinearOperators, Printf, SparseArrays, FastClosures
 
 export AbstractNLPModelMeta, NLPModelMeta, AbstractNLPModel, Counters
@@ -86,14 +94,14 @@ end
 # Methods to be overridden in other packages.
 """`f = obj(nlp, x)`
 
-Evaluate \$f(x)\$, the objective function of `nlp` at `x`.
+Evaluate ``f(x)``, the objective function of `nlp` at `x`.
 """
 obj(::AbstractNLPModel, ::AbstractVector) =
   throw(NotImplementedError("obj"))
 
 """`g = grad(nlp, x)`
 
-Evaluate \$\\nabla f(x)\$, the gradient of the objective function at `x`.
+Evaluate ``∇f(x)``, the gradient of the objective function at `x`.
 """
 function grad(nlp::AbstractNLPModel, x::AbstractVector)
   g = similar(x)
@@ -102,14 +110,14 @@ end
 
 """`g = grad!(nlp, x, g)`
 
-Evaluate \$\\nabla f(x)\$, the gradient of the objective function at `x` in place.
+Evaluate ``∇f(x)``, the gradient of the objective function at `x` in place.
 """
 grad!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector) =
   throw(NotImplementedError("grad!"))
 
 """`c = cons(nlp, x)`
 
-Evaluate \$c(x)\$, the constraints at `x`.
+Evaluate ``c(x)``, the constraints at `x`.
 """
 function cons(nlp::AbstractNLPModel, x::AbstractVector)
   c = similar(x, nlp.meta.ncon)
@@ -118,7 +126,7 @@ end
 
 """`c = cons!(nlp, x, c)`
 
-Evaluate \$c(x)\$, the constraints at `x` in place.
+Evaluate ``c(x)``, the constraints at `x` in place.
 """
 cons!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector) =
   throw(NotImplementedError("cons!"))
@@ -134,7 +142,7 @@ jth_sparse_congrad(::AbstractNLPModel, ::AbstractVector, ::Integer) =
 
 """`f, c = objcons(nlp, x)`
 
-Evaluate \$f(x)\$ and \$c(x)\$ at `x`.
+Evaluate ``f(x)`` and ``c(x)`` at `x`.
 """
 function objcons(nlp, x)
   f = obj(nlp, x)
@@ -144,7 +152,7 @@ end
 
 """`f = objcons!(nlp, x, c)`
 
-Evaluate \$f(x)\$ and \$c(x)\$ at `x`. `c` is overwritten with the value of \$c(x)\$.
+Evaluate ``f(x)`` and ``c(x)`` at `x`. `c` is overwritten with the value of ``c(x)``.
 """
 function objcons!(nlp, x, c)
   f = obj(nlp, x)
@@ -154,7 +162,7 @@ end
 
 """`f, g = objgrad(nlp, x)`
 
-Evaluate \$f(x)\$ and \$\\nabla f(x)\$ at `x`.
+Evaluate ``f(x)`` and ``∇f(x)`` at `x`.
 """
 function objgrad(nlp, x)
   f = obj(nlp, x)
@@ -164,8 +172,8 @@ end
 
 """`f, g = objgrad!(nlp, x, g)`
 
-Evaluate \$f(x)\$ and \$\\nabla f(x)\$ at `x`. `g` is overwritten with the
-value of \$\\nabla f(x)\$.
+Evaluate ``f(x)`` and ``∇f(x)`` at `x`. `g` is overwritten with the
+value of ``∇f(x)``.
 """
 function objgrad!(nlp, x, g)
   f = obj(nlp, x)
@@ -181,26 +189,26 @@ jac_structure(:: AbstractNLPModel) = throw(NotImplementedError("jac_structure"))
 
 """`(rows,cols,vals) = jac_coord!(nlp, x, rows, cols, vals)`
 
-Evaluate \$\\nabla c(x)\$, the constraint's Jacobian at `x` in sparse coordinate format,
+Evaluate ``∇c(x)``, the constraint's Jacobian at `x` in sparse coordinate format,
 rewriting `vals`. `rows` and `cols` are not rewritten.
 """
 jac_coord!(:: AbstractNLPModel, :: AbstractVector) = throw(NotImplementedError("jac_coord!"))
 
 """`(rows,cols,vals) = jac_coord(nlp, x)`
 
-Evaluate \$\\nabla c(x)\$, the constraint's Jacobian at `x` in sparse coordinate format.
+Evaluate ``∇c(x)``, the constraint's Jacobian at `x` in sparse coordinate format.
 """
 jac_coord(:: AbstractNLPModel, :: AbstractVector) = throw(NotImplementedError("jac_coord"))
 
 """`Jx = jac(nlp, x)`
 
-Evaluate \$\\nabla c(x)\$, the constraint's Jacobian at `x` as a sparse matrix.
+Evaluate ``∇c(x)``, the constraint's Jacobian at `x` as a sparse matrix.
 """
 jac(::AbstractNLPModel, ::AbstractVector) = throw(NotImplementedError("jac"))
 
 """`Jv = jprod(nlp, x, v)`
 
-Evaluate \$\\nabla c(x)v\$, the Jacobian-vector product at `x`.
+Evaluate ``∇c(x)v``, the Jacobian-vector product at `x`.
 """
 function jprod(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector)
   Jv = similar(v, nlp.meta.ncon)
@@ -209,14 +217,14 @@ end
 
 """`Jv = jprod!(nlp, x, v, Jv)`
 
-Evaluate \$\\nabla c(x)v\$, the Jacobian-vector product at `x` in place.
+Evaluate ``∇c(x)v``, the Jacobian-vector product at `x` in place.
 """
 jprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector) =
   throw(NotImplementedError("jprod!"))
 
 """`Jtv = jtprod(nlp, x, v, Jtv)`
 
-Evaluate \$\\nabla c(x)^Tv\$, the transposed-Jacobian-vector product at `x`.
+Evaluate ``∇c(x)^Tv``, the transposed-Jacobian-vector product at `x`.
 """
 function jtprod(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector)
   Jtv = similar(x)
@@ -225,7 +233,7 @@ end
 
 """`Jtv = jtprod!(nlp, x, v, Jtv)`
 
-Evaluate \$\\nabla c(x)^Tv\$, the transposed-Jacobian-vector product at `x` in place.
+Evaluate ``∇c(x)^Tv``, the transposed-Jacobian-vector product at `x` in place.
 """
 jtprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector) =
   throw(NotImplementedError("jtprod!"))
@@ -281,10 +289,7 @@ hess_structure(:: AbstractNLPModel) = throw(NotImplementedError("hess_structure"
 
 Evaluate the Lagrangian Hessian at `(x,y)` in sparse coordinate format,
 with objective function scaled by `obj_weight`, i.e.,
-
-\\\\[ \\nabla^2L(x,y) = \\sigma * \\nabla^2 f(x) + \\sum_{i=1}^m y_i\\nabla^2 c_i(x), \\\\]
-
-with σ = obj_weight, rewriting `vals`. `rows` and `cols` are not rewritten.
+$(LAGRANGIAN_HESSION),rewriting `vals`. `rows` and `cols` are not rewritten.
 Only the lower triangle is returned.
 """
 hess_coord!(:: AbstractNLPModel, :: AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, ::AbstractVector; kwargs...) = throw(NotImplementedError("hess_coord!"))
@@ -294,9 +299,7 @@ hess_coord!(:: AbstractNLPModel, :: AbstractVector, ::AbstractVector{<: Integer}
 Evaluate the Lagrangian Hessian at `(x,y)` in sparse coordinate format,
 with objective function scaled by `obj_weight`, i.e.,
 
-\\\\[ \\nabla^2L(x,y) = \\sigma * \\nabla^2 f(x) + \\sum_{i=1}^m y_i\\nabla^2 c_i(x), \\\\]
-
-with σ = obj_weight.
+$(LAGRANGIAN_HESSION).
 Only the lower triangle is returned.
 """
 hess_coord(nlp::AbstractNLPModel, x::AbstractVector; y::AbstractVector=Float64[], obj_weight::Real=1.0) = throw(NotImplementedError("hess_coord"))
@@ -306,9 +309,7 @@ hess_coord(nlp::AbstractNLPModel, x::AbstractVector; y::AbstractVector=Float64[]
 Evaluate the Lagrangian Hessian at `(x,y)` as a sparse matrix,
 with objective function scaled by `obj_weight`, i.e.,
 
-\\\\[ \\nabla^2L(x,y) = \\sigma * \\nabla^2 f(x) + \\sum_{i=1}^m y_i\\nabla^2 c_i(x), \\\\]
-
-with σ = obj_weight.
+$(LAGRANGIAN_HESSION).
 Only the lower triangle is returned.
 """
 hess(::AbstractNLPModel, ::AbstractVector; kwargs...) =
@@ -317,11 +318,8 @@ hess(::AbstractNLPModel, ::AbstractVector; kwargs...) =
 """`Hv = hprod(nlp, x, v; obj_weight=1.0, y=zeros)`
 
 Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v`,
-with objective function scaled by `obj_weight`, i.e.,
-
-\\\\[ \\nabla^2L(x,y) = \\sigma * \\nabla^2 f(x) + \\sum_{i=1}^m y_i\\nabla^2 c_i(x), \\\\]
-
-with σ = obj_weight.
+with objective function scaled by `obj_weight`, where the Lagrangian Hessian is
+$(LAGRANGIAN_HESSION).
 """
 function hprod(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector; obj_weight::Real = one(eltype(x)), y::AbstractVector=similar(x, 0))
   Hv = similar(x)
@@ -331,11 +329,8 @@ end
 """`Hv = hprod!(nlp, x, v, Hv; obj_weight=1.0, y=zeros)`
 
 Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
-place, with objective function scaled by `obj_weight`, i.e.,
-
-\\\\[ \\nabla^2L(x,y) = \\sigma * \\nabla^2 f(x) + \\sum_{i=1}^m y_i\\nabla^2 c_i(x), \\\\]
-
-with σ = obj_weight.
+place, with objective function scaled by `obj_weight`, where the Lagrangian Hessian is
+$(LAGRANGIAN_HESSION).
 """
 hprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector; kwargs...) =
   throw(NotImplementedError("hprod!"))
@@ -345,10 +340,7 @@ hprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector;
 Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
 `obj_weight` as a linear operator. The resulting object may be used as if it were a
 matrix, e.g., `H * v`. The linear operator H represents
-
-\\\\[ \\nabla^2L(x,y) = \\sigma * \\nabla^2 f(x) + \\sum_{i=1}^m y_i\\nabla^2 c_i(x), \\\\]
-
-with σ = obj_weight.
+$(LAGRANGIAN_HESSION).
 """
 function hess_op(nlp :: AbstractNLPModel, x :: AbstractVector;
                  obj_weight :: Float64=1.0, y :: AbstractVector=zeros(nlp.meta.ncon))
@@ -365,10 +357,7 @@ Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
 object may be used as if it were a matrix, e.g., `w = H * v`. The vector `Hv` is
 used as preallocated storage for the operation.  The linear operator H
 represents
-
-\\\\[ \\nabla^2L(x,y) = \\sigma * \\nabla^2 f(x) + \\sum_{i=1}^m y_i\\nabla^2 c_i(x), \\\\]
-
-with σ = obj_weight.
+$(LAGRANGIAN_HESSION).
 """
 function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, Hv :: AbstractVector;
                  obj_weight :: Float64=1.0, y :: AbstractVector=zeros(nlp.meta.ncon))

--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -4,11 +4,11 @@ __precompile__()
 module NLPModels
 
 # For documentation purpose
-const LAGRANGIAN_HESSION = raw"""
+const LAGRANGIAN_HESSIAN = raw"""
 ```math
-∇²L(x,y) = σ ∇²f(x) + ∑_i yᵢ ∇²cᵢ(x),
+∇²L(x,y) = σ ∇²f(x) + ∑ᵢ yᵢ ∇²cᵢ(x),
 ```
-with σ = obj_weight
+with `σ = obj_weight`
 """
 
 using LinearAlgebra, LinearOperators, Printf, SparseArrays, FastClosures
@@ -289,7 +289,7 @@ hess_structure(:: AbstractNLPModel) = throw(NotImplementedError("hess_structure"
 
 Evaluate the Lagrangian Hessian at `(x,y)` in sparse coordinate format,
 with objective function scaled by `obj_weight`, i.e.,
-$(LAGRANGIAN_HESSION),rewriting `vals`. `rows` and `cols` are not rewritten.
+$(LAGRANGIAN_HESSIAN),rewriting `vals`. `rows` and `cols` are not rewritten.
 Only the lower triangle is returned.
 """
 hess_coord!(:: AbstractNLPModel, :: AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, ::AbstractVector; kwargs...) = throw(NotImplementedError("hess_coord!"))
@@ -299,7 +299,7 @@ hess_coord!(:: AbstractNLPModel, :: AbstractVector, ::AbstractVector{<: Integer}
 Evaluate the Lagrangian Hessian at `(x,y)` in sparse coordinate format,
 with objective function scaled by `obj_weight`, i.e.,
 
-$(LAGRANGIAN_HESSION).
+$(LAGRANGIAN_HESSIAN).
 Only the lower triangle is returned.
 """
 hess_coord(nlp::AbstractNLPModel, x::AbstractVector; y::AbstractVector=Float64[], obj_weight::Real=1.0) = throw(NotImplementedError("hess_coord"))
@@ -309,7 +309,7 @@ hess_coord(nlp::AbstractNLPModel, x::AbstractVector; y::AbstractVector=Float64[]
 Evaluate the Lagrangian Hessian at `(x,y)` as a sparse matrix,
 with objective function scaled by `obj_weight`, i.e.,
 
-$(LAGRANGIAN_HESSION).
+$(LAGRANGIAN_HESSIAN).
 Only the lower triangle is returned.
 """
 hess(::AbstractNLPModel, ::AbstractVector; kwargs...) =
@@ -319,7 +319,7 @@ hess(::AbstractNLPModel, ::AbstractVector; kwargs...) =
 
 Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v`,
 with objective function scaled by `obj_weight`, where the Lagrangian Hessian is
-$(LAGRANGIAN_HESSION).
+$(LAGRANGIAN_HESSIAN).
 """
 function hprod(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector; obj_weight::Real = one(eltype(x)), y::AbstractVector=similar(x, 0))
   Hv = similar(x)
@@ -330,7 +330,7 @@ end
 
 Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
 place, with objective function scaled by `obj_weight`, where the Lagrangian Hessian is
-$(LAGRANGIAN_HESSION).
+$(LAGRANGIAN_HESSIAN).
 """
 hprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector; kwargs...) =
   throw(NotImplementedError("hprod!"))
@@ -340,7 +340,7 @@ hprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector;
 Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
 `obj_weight` as a linear operator. The resulting object may be used as if it were a
 matrix, e.g., `H * v`. The linear operator H represents
-$(LAGRANGIAN_HESSION).
+$(LAGRANGIAN_HESSIAN).
 """
 function hess_op(nlp :: AbstractNLPModel, x :: AbstractVector;
                  obj_weight :: Float64=1.0, y :: AbstractVector=zeros(nlp.meta.ncon))
@@ -357,7 +357,7 @@ Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
 object may be used as if it were a matrix, e.g., `w = H * v`. The vector `Hv` is
 used as preallocated storage for the operation.  The linear operator H
 represents
-$(LAGRANGIAN_HESSION).
+$(LAGRANGIAN_HESSIAN).
 """
 function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, Hv :: AbstractVector;
                  obj_weight :: Float64=1.0, y :: AbstractVector=zeros(nlp.meta.ncon))

--- a/src/autodiff_model.jl
+++ b/src/autodiff_model.jl
@@ -18,7 +18,7 @@ ADNLPModel(f, x0; lvar = [-∞,…,-∞], uvar = [∞,…,∞], y0 = zeros,
 
   - `f :: Function` - The objective function ``f``;
   - `x0 :: AbstractVector` - The initial point of the problem;
-  - `lvar :: AbstractVector` - ``l``, the lower bound of the variables;
+  - `lvar :: AbstractVector` - ``ℓ``, the lower bound of the variables;
   - `uvar :: AbstractVector` - ``u``, the upper bound of the variables;
   - `c :: Function` - The constraints function ``c``;
   - `y0 :: AbstractVector` - The initial value of the Lagrangian estimates;

--- a/src/autodiff_model.jl
+++ b/src/autodiff_model.jl
@@ -3,12 +3,12 @@ using ForwardDiff
 export ADNLPModel, obj, grad, grad!, cons, cons!, jac, jprod,
        jprod!, jtprod, jtprod!, hess, hprod, hprod!
 
-"""ADNLPModel is an AbstractNLPModel using ForwardDiff to compute the
+@doc raw"""ADNLPModel is an AbstractNLPModel using ForwardDiff to compute the
 derivatives.
-In this interface, the objective function \$f\$ and an initial estimate are
+In this interface, the objective function ``f`` and an initial estimate are
 required. If there are constraints, the function
-\$c:\\mathbb{R}^n\\rightarrow\\mathbb{R}^m\$  and the vectors
-\$c_L\$ and \$c_U\$ also need to be passed. Bounds on the variables and an
+``c:ℝⁿ → ℝᵐ``  and the vectors
+``c_L`` and ``c_U`` also need to be passed. Bounds on the variables and an
 inital estimate to the Lagrangian multipliers can also be provided.
 
 ````
@@ -16,14 +16,14 @@ ADNLPModel(f, x0; lvar = [-∞,…,-∞], uvar = [∞,…,∞], y0 = zeros,
   c = NotImplemented, lcon = [-∞,…,-∞], ucon = [∞,…,∞], name = "Generic")
 ````
 
-  - `f :: Function` - The objective function \$f\$;
+  - `f :: Function` - The objective function ``f``;
   - `x0 :: AbstractVector` - The initial point of the problem;
-  - `lvar :: AbstractVector` - \$\\ell\$, the lower bound of the variables;
-  - `uvar :: AbstractVector` - \$u\$, the upper bound of the variables;
-  - `c :: Function` - The constraints function \$c\$;
+  - `lvar :: AbstractVector` - ``l``, the lower bound of the variables;
+  - `uvar :: AbstractVector` - ``u``, the upper bound of the variables;
+  - `c :: Function` - The constraints function ``c``;
   - `y0 :: AbstractVector` - The initial value of the Lagrangian estimates;
-  - `lcon :: AbstractVector` - \$c_L\$, the lower bounds of the constraints function;
-  - `ucon :: AbstractVector` - \$c_U\$, the upper bounds of the constraints function;
+  - `lcon :: AbstractVector` - ``c_L``, the lower bounds of the constraints function;
+  - `ucon :: AbstractVector` - ``c_U``, the upper bounds of the constraints function;
   - `name :: String` - A name for the model.
 
 The functions follow the same restrictions of ForwardDiff functions, summarised
@@ -34,10 +34,10 @@ here:
   - The function's argument must accept a subtype of AbstractVector;
   - The function should be type-stable.
 
-For contrained problems, the function \$c\$ is required, and it must return
+For contrained problems, the function ``c`` is required, and it must return
 an array even when m = 1,
-and \$c_L\$ and \$c_U\$ should be passed, otherwise the problem is ill-formed.
-For equality constraints, the corresponding index of \$c_L\$ and \$c_U\$ should be the
+and ``c_L`` and ``c_U`` should be passed, otherwise the problem is ill-formed.
+For equality constraints, the corresponding index of ``c_L`` and ``c_U`` should be the
 same.
 """
 mutable struct ADNLPModel <: AbstractNLPModel

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -37,7 +37,7 @@ The unknowns ``X = (x, s)`` contain the original variables and slack variables
 \begin{align*}
        \min_x \quad & f(x)\\
 \mathrm{s.t.} \quad & c(x) - s = 0,\\
-                    & c_L ≤ x ≤ c_U,\\
+                    & c_L ≤ s ≤ c_U,\\
                     &  ℓ  ≤ x ≤ u.
 \end{align*}
 ```

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -14,11 +14,9 @@ form
 
 ```math
 \begin{align*}
-&\min_x        && f(x)\\
-&\mathrm{s.t.} && \begin{alignedat}[t]{3}
-                    c_L &≤ c(x) &&≤ c_U,\\
-                     ℓ  &≤  x   &&≤  u,
-                  \end{alignedat}
+       \min_x \quad & f(x)\\
+\mathrm{s.t.} \quad & c_L ≤ c(x) ≤ c_U,\\
+                    &  ℓ  ≤  x   ≤  u,
 \end{align*}
 ```
 
@@ -26,9 +24,9 @@ the new model appears to the user as
 
 ```math
 \begin{align*}
-&\min_X        & &f(X)\\
-&\mathrm{s.t.} & &g(X) = 0,\\
-&              & &L ≤ X ≤ U.
+       \min_X \quad & f(X)\\
+\mathrm{s.t.} \quad & g(X) = 0,\\
+                    & L ≤ X ≤ U.
 \end{align*}
 ```
 
@@ -37,12 +35,10 @@ The unknowns ``X = (x, s)`` contain the original variables and slack variables
 
 ```math
 \begin{align*}
-&\min_x     & &f(x)\\
-&\mathrm{s.t.} & &c(x) - s = 0,\\
-&              & &\begin{alignedat}[t]{3}
-                    c_L &≤ x &&≤ c_U,\\
-                     ℓ  &≤ x &&≤ u.
-                  \end{alignedat}
+       \min_x \quad & f(x)\\
+\mathrm{s.t.} \quad & c(x) - s = 0,\\
+                    & c_L ≤ x ≤ c_U,\\
+                    &  ℓ  ≤ x ≤ u.
 \end{align*}
 ```
 

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -17,7 +17,7 @@ form
 &\min_x        && f(x)\\
 &\mathrm{s.t.} && \begin{alignedat}[t]{3}
                     c_L &≤ c(x) &&≤ c_U,\\
-                     l  &≤  x   &&≤  u,
+                     ℓ  &≤  x   &&≤  u,
                   \end{alignedat}
 \end{align*}
 ```
@@ -41,7 +41,7 @@ The unknowns ``X = (x, s)`` contain the original variables and slack variables
 &\mathrm{s.t.} & &c(x) - s = 0,\\
 &              & &\begin{alignedat}[t]{3}
                     c_L &≤ x &&≤ c_U,\\
-                     l  &≤ x &&≤ u.
+                     ℓ  &≤ x &&≤ u.
                   \end{alignedat}
 \end{align*}
 ```

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -13,36 +13,42 @@ equality constraints and bounds. More precisely, if the original model has the
 form
 
 ```math
-\begin{align}
-&\min_x      & &f(x)\\
-&\text{s.t.} & &\begin{array}{ccccc}
-                  c_L &≤& c(x) &≤& c_U,\\
-                   l  &≤&   x  &≤&  u,
-                \end{array}
-\end{align}
+\begin{align*}
+&\min_x        && f(x)\\
+&\mathrm{s.t.} && \begin{alignedat}[t]{3}
+                    c_L &≤ c(x) &&≤ c_U,\\
+                     l  &≤  x   &&≤  u,
+                  \end{alignedat}
+\end{align*}
 ```
 
 the new model appears to the user as
 
 ```math
-&\min_X      & &f(X)\\
-&\text{s.t.} & &g(X) = 0,\\
-&            & &L ≤ X ≤ U.
+\begin{align*}
+&\min_X        & &f(X)\\
+&\mathrm{s.t.} & &g(X) = 0,\\
+&              & &L ≤ X ≤ U.
+\end{align*}
 ```
 
 The unknowns ``X = (x, s)`` contain the original variables and slack variables
 ``s``. The latter are such that the new model has the general form
 
 ```math
-&\min_Xx     & &f(x)\\
-&\text{s.t.} & &c(x) - s = 0,\\
-&            & &c_L ≤ x ≤ c_U,\\
-&            & & l  ≤ x ≤ u.
+\begin{align*}
+&\min_x     & &f(x)\\
+&\mathrm{s.t.} & &c(x) - s = 0,\\
+&              & &\begin{alignedat}[t]{3}
+                    c_L &≤ x &&≤ c_U,\\
+                     l  &≤ x &&≤ u.
+                  \end{alignedat}
+\end{align*}
 ```
 
 although no slack variables are introduced for equality constraints.
 
-The slack variables are implicitly ordered as [s(low), s(upp), s(rng)], where
+The slack variables are implicitly ordered as `[s(low), s(upp), s(rng)]`, where
 `low`, `upp` and `rng` represent the indices of the constraints of the form
 ``c_L ≤ c(x) < ∞``, ``-∞ < c(x) ≤ c_U`` and
 ``c_L ≤ c(x) ≤ c_U``, respectively.

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -5,32 +5,47 @@ export SlackModel, SlackNLSModel,
        hess_coord, hess, hprod, hprod!
 
 
-"""A model whose only inequality constraints are bounds.
+@doc raw"""A model whose only inequality constraints are bounds.
 
 Given a model, this type represents a second model in which slack variables are
 introduced so as to convert linear and nonlinear inequality constraints to
 equality constraints and bounds. More precisely, if the original model has the
 form
 
-\\\\[ \\min f(x)  \\mbox{ s. t. }  c_L \\leq c(x) \\leq c_U \\mbox{ and }
-\\ell \\leq x \\leq u, \\\\]
+```math
+\begin{align}
+&\min_x      & &f(x)\\
+&\text{s.t.} & &\begin{array}{ccccc}
+                  c_L &≤& c(x) &≤& c_U,\\
+                   l  &≤&   x  &≤&  u,
+                \end{array}
+\end{align}
+```
 
 the new model appears to the user as
 
-\\\\[ \\min f(X)  \\mbox{ s. t. }  g(X) = 0 \\mbox{ and } L \\leq X \\leq U. \\\\]
+```math
+&\min_X      & &f(X)\\
+&\text{s.t.} & &g(X) = 0,\\
+&            & &L ≤ X ≤ U.
+```
 
-The unknowns \$X = (x, s)\$ contain the original variables and slack variables
-\$s\$. The latter are such that the new model has the general form
+The unknowns ``X = (x, s)`` contain the original variables and slack variables
+``s``. The latter are such that the new model has the general form
 
-\\\\[ \\min f(x)  \\mbox{ s. t. }  c(x) - s = 0, c_L \\leq s \\leq c_U \\mbox{ and }
-\\ell \\leq x \\leq u, \\\\]
+```math
+&\min_Xx     & &f(x)\\
+&\text{s.t.} & &c(x) - s = 0,\\
+&            & &c_L ≤ x ≤ c_U,\\
+&            & & l  ≤ x ≤ u.
+```
 
 although no slack variables are introduced for equality constraints.
 
 The slack variables are implicitly ordered as [s(low), s(upp), s(rng)], where
 `low`, `upp` and `rng` represent the indices of the constraints of the form
-\$c_L \\leq c(x) < \\infty\$, \$-\\infty < c(x) \\leq c_U\$ and
-\$c_L \\leq c(x) \\leq c_U\$, respectively.
+``c_L ≤ c(x) < ∞``, ``-∞ < c(x) ≤ c_U`` and
+``c_L ≤ c(x) ≤ c_U``, respectively.
 """
 mutable struct SlackModel <: AbstractNLPModel
   meta :: NLPModelMeta


### PR DESCRIPTION
Thank you for your great packages! I'm using NLPModels, CUTEst, NLPModelsJuMP and SolverTools for my research and they saved me a lot of time. I just realized some math display issues in your documentations (e.g. [here](http://juliasmoothoptimizers.github.io/NLPModels.jl/latest/api/#NLPModels.hess) and [here](http://juliasmoothoptimizers.github.io/NLPModels.jl/latest/models/#SlackModel-1)). So I tried to fix the problem.

Changes include:
- display math: fixed issues mentioned above,
- inline math: replaced `\$` by ` `` `,
- latex: replaced latex commands by unicode symbols for better docstring in REPL.

I'm pretty new to julia as well as collaborating on github. Let me know if I did anything stupid.
Thanks.