### PR TITLE
Change coverage in travis to run only for one build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,8 @@ jobs:
       after_success: skip
 
 after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'if Sys.islinux() && string(VERSION)[1:3] == "1.2"
+      using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())
+    else
+      println("Coverage skipped")
+    end'


### PR DESCRIPTION
Might be interesting to have `isunix` instead of `islinux` for some packages, but NLPModels doesn't have any specific OS code. 
On Windows the coverage submission sends wrong filenames, which can't be explored (`src\NLPModels.jl` instead of `src/NLPModels.jl`).