### PR TITLE
Rework NLS consistency tests

### DIFF
--- a/test/nls_consistency.jl
+++ b/test/nls_consistency.jl
@@ -141,198 +141,36 @@ function consistent_nls_functions(nlss; rtol=1.0e-8, exclude=[])
   end
 end
 
-function consistent_nls()
-  @testset "Consistency of Linear problem" begin
-    m, n = 50, 20
-    A = Matrix(1.0I, m, n) .+ 1
-    b = collect(1:m)
-    lvar = -ones(n)
-    uvar = ones(n)
-    lls_model = LLSModel(A, b, lvar=lvar, uvar=uvar)
-    autodiff_model = ADNLSModel(x->A*x-b, zeros(n), m, lvar=lvar, uvar=uvar)
-    nlp = ADNLPModel(x->0, zeros(n), lvar=lvar, uvar=uvar, c=x->A*x-b,
-                     lcon=zeros(m), ucon=zeros(m))
-    feas_res_model = FeasibilityResidual(nlp)
-    nlss = [lls_model, autodiff_model, feas_res_model]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss)
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    for nls in nlss
-      reset!(nls)
-    end
-
-    f(x) = begin
-      r = A*x - b
-      return 0.5*dot(r, r)
-    end
-    nlps = [nlss; ADNLPModel(f, zeros(n))]
-    consistent_functions(nlps, exclude=[hess_coord])
+function consistent_nlss(nlss; exclude=[hess, hprod, hess_coord])
+  consistent_nls_counters(nlss)
+  consistent_counters(nlss)
+  consistent_nls_functions(nlss, exclude=exclude)
+  consistent_nls_counters(nlss)
+  consistent_counters(nlss)
+  for nls in nlss
+    reset!(nls)
   end
+  consistent_functions(nlss, exclude=exclude)
 
-  @testset "Consistency of Linear problem with linear constraints" begin
-    m, n = 50, 20
-    A = Matrix(1.0I, m, n) .+ 1
-    b = collect(1:m)
-    lvar = -ones(n)
-    uvar = ones(n)
-    nc = 10
-    C = [ones(nc, n); 2 * ones(nc, n); -ones(nc, n); -Matrix(1.0I, nc, n)]
-    lcon = [   zeros(nc); -ones(nc); fill(-Inf,nc); zeros(nc)]
-    ucon = [fill(Inf,nc);  ones(nc);     zeros(nc); zeros(nc)]
-    K = ((1:4:4nc) .+ (0:3)')[:]
-    lcon, ucon = lcon[K], ucon[K]
-    lls_model = LLSModel(A, b, lvar=lvar, uvar=uvar, C=C, lcon=lcon,
-                         ucon=ucon)
-    autodiff_model = ADNLSModel(x->A*x-b, zeros(n), m, lvar=lvar,
-                                uvar=uvar, c=x->C*x, lcon=lcon,
-                                ucon=ucon)
-    nlss = [lls_model, autodiff_model]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss)
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_functions(nlss, exclude=[hess_coord])
+  snlss = [SlackNLSModel(nls) for nls in nlss]
+  for nls in snlss
+    reset!(nls)
   end
+  consistent_nls_counters(snlss)
+  consistent_counters(snlss)
+  consistent_nls_functions(snlss, exclude=exclude)
+  consistent_nls_counters(snlss)
+  consistent_counters(snlss)
+  consistent_functions(snlss, exclude=exclude)
 
-  @testset "Consistency of Nonlinear problem" begin
-    m, n = 10, 2
-    lvar = -ones(n)
-    uvar =  ones(n)
-    F(x) = [2 + 2i - exp(i*x[1]) - exp(i*x[2]) for i = 1:m]
-    x0 = [0.3; 0.4]
-
-    autodiff_model = ADNLSModel(F, x0, m, lvar=lvar, uvar=uvar)
-    nlp = ADNLPModel(x->0, x0, lvar=lvar, uvar=uvar, c=F, lcon=zeros(m), ucon=zeros(m))
-    feas_res_model = FeasibilityResidual(nlp)
-    nlss = [autodiff_model, feas_res_model]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss)
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    for nls in nlss
-      reset!(nls)
-    end
-
-    f(x) = begin
-      r = F(x)
-      return 0.5*dot(r, r)
-    end
-    nlps = [nlss; ADNLPModel(f, zeros(n))]
-    consistent_functions(nlps, exclude=[hess_coord])
+  fnlss = [FeasibilityFormNLS(nls) for nls in nlss]
+  for nls in fnlss
+    reset!(nls)
   end
-
-  @testset "Consistency of Nonlinear problem with constraints" begin
-    m, n = 10, 2
-    lvar = -ones(n)
-    uvar =  ones(n)
-    F(x) = [2 + 2i - exp(i*x[1]) - exp(i*x[2]) for i = 1:m]
-    x0 = [0.3; 0.4]
-    c(x) = [x[1]^2 - x[2]^2; 2 * x[1] * x[2]; x[1] + x[2]]
-    lcon = [0.0; -1.0; -Inf]
-    ucon = [Inf;  1.0;  0.0]
-
-    autodiff_model = ADNLSModel(F, x0, m, lvar=lvar, uvar=uvar,
-                                lcon=lcon, ucon=ucon, c=c)
-    nlss = [autodiff_model]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss)
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_functions(nlss, exclude=[hess_coord])
-  end
-
-  @testset "Consistency of slack variant" begin
-    F(x) = [x[1] - 1.0;
-            x[2] - x[1]^2;
-            sin(x[1] * x[2]) * x[3]]
-    x0 = [0.3; 0.4; 0.5]
-    c(x) = [x[1]^2 - x[2]^2;
-            2 * x[1] * x[2];
-            x[1] + x[2];
-            cos(x[1]) - x[2]]
-    lcon = [0.0; -1.0; -Inf; 0.0]
-    ucon = [Inf;  1.0;  0.0; 0.0]
-    nls = ADNLSModel(F, x0, 3, c=c, lcon=lcon, ucon=ucon)
-
-    nls_manual_slack = ADNLSModel(F, [x0; zeros(3)], 3,
-                                  c=x->c(x) - [x[4]; x[6]; x[5]; 0.0],
-                                  lcon=zeros(4), ucon=zeros(4),
-                                  lvar=[-Inf; -Inf; -Inf; 0.0; -Inf; -1.0],
-                                  uvar=[Inf; Inf; Inf; Inf; 0.0; 1.0])
-
-    nls_auto_slack = SlackNLSModel(nls)
-    nlss = [nls_manual_slack, nls_auto_slack]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss)
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_functions(nlss)
-  end
-
-  @testset "Consistency of slack variant for linear problem" begin
-    A = [1.0 0.0; 1.0 2.0; 2.0 1.0]
-    b = [1.0; 3.0; 2.0]
-    C = [1.0 1.0; 1.0 -1.0; 2.0 1.0; 1.0 2.0]
-    x0 = ones(2)
-    lcon = [0.0; -1.0; -Inf; 0.0]
-    ucon = [Inf;  1.0;  0.0; 0.0]
-    adnls = ADNLSModel(x -> A*x - b, x0, 3, c=x -> C*x, lcon=lcon, ucon=ucon)
-    lls = LLSModel(A, b, x0=x0, C=C, lcon=lcon, ucon=ucon)
-
-    nlss = [SlackNLSModel(adnls), SlackNLSModel(lls)]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss)
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_functions(nlss, exclude=[hess_coord])
-  end
-
-  @testset "Consistency of LLS with Matrix and LinearOperator" begin
-    m, n = 50, 20
-    A = Matrix(1.0I, m, n) .+ 1
-    b = collect(1:m)
-    lls = LLSModel(A, b)
-    lls2 = LLSModel(LinearOperator(A), b)
-    nlss = [lls, lls2]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss, exclude=[jac_residual])
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-
-    nc = 10
-    C = [ones(nc, n); 2 * ones(nc, n); -ones(nc, n); -Matrix(1.0I, nc, n)]
-    lcon = [   zeros(nc); -ones(nc); fill(-Inf,nc); zeros(nc)]
-    ucon = [fill(Inf,nc);  ones(nc);     zeros(nc); zeros(nc)]
-    K = ((1:4:4nc) .+ (0:3)')[:]
-    lcon, ucon = lcon[K], ucon[K]
-    lls  = LLSModel(A, b, C=C, lcon=lcon, ucon=ucon)
-    lls2 = LLSModel(LinearOperator(A), b, C=C, lcon=lcon, ucon=ucon)
-    lls3 = LLSModel(A, b, C=LinearOperator(C), lcon=lcon, ucon=ucon)
-    lls4 = LLSModel(LinearOperator(A), b, C=LinearOperator(C), lcon=lcon, ucon=ucon)
-    nlss = [lls, lls2, lls3, lls4]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss, exclude=[jac_residual, hess_coord_residual])
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-
-    for nls in nlss
-      reset!(nls)
-    end
-    nlss = [SlackNLSModel(nls) for nls in nlss]
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-    consistent_nls_functions(nlss, exclude=[jac_residual, hess_coord_residual])
-    consistent_nls_counters(nlss)
-    consistent_counters(nlss)
-  end
-
+  consistent_nls_counters(fnlss)
+  consistent_counters(fnlss)
+  consistent_nls_functions(fnlss, exclude=exclude)
+  consistent_nls_counters(fnlss)
+  consistent_counters(fnlss)
+  consistent_functions(fnlss, exclude=exclude)
 end

--- a/test/nls_problems/lls.jl
+++ b/test/nls_problems/lls.jl
@@ -1,0 +1,112 @@
+using NLPModels: increment!
+
+function lls_autodiff()
+
+  x0 = [0.0; 0.0]
+  F(x) = [x[1] - x[2]; x[1] + x[2] - 2; x[2] - 2]
+  c(x) = [x[1] + x[2]]
+  lcon = [0.0]
+  ucon = [Inf]
+
+  return ADNLSModel(F, x0, 3, c=c, lcon=lcon, ucon=ucon)
+end
+
+function lls_special()
+  return LLSModel([1.0 -1; 1 1; 0 1], [0.0; 2; 2], x0=zeros(2), C=[1.0 1], lcon=[0.0], ucon=[Inf])
+end
+
+
+mutable struct LLS <: AbstractNLSModel
+  meta :: NLPModelMeta
+  nls_meta :: NLSMeta
+  counters :: NLSCounters
+end
+
+function LLS()
+  meta = NLPModelMeta(2, x0=zeros(2), name="LLS", ncon=1, lcon=[0.0], ucon=[Inf], nnzj=2)
+  nls_meta = NLSMeta(3, 2, nnzj=5, nnzh=0)
+
+  return LLS(meta, nls_meta, NLSCounters())
+end
+
+function NLPModels.residual!(nls :: LLS, x :: AbstractVector, Fx :: AbstractVector)
+  increment!(nls, :neval_residual)
+  Fx[1:3] .= [x[1] - x[2]; x[1] + x[2] - 2; x[2] - 2]
+  return Fx
+end
+
+function NLPModels.jac_structure_residual!(nls :: LLS, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1:5] .= [1, 1, 2, 2, 3]
+  cols[1:5] .= [1, 2, 1, 2, 2]
+  return rows, cols
+end
+
+function NLPModels.jac_coord_residual!(nls :: LLS, x :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_jac_residual)
+  T = eltype(x)
+  vals[1:5] .= T[1, -1, 1, 1, 1]
+  return vals
+end
+
+function NLPModels.jprod_residual!(nls :: LLS, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
+  increment!(nls, :neval_jprod_residual)
+  Jv[1:3] .= [v[1] - v[2]; v[1] + v[2]; v[2]]
+  return Jv
+end
+
+function NLPModels.jtprod_residual!(nls :: LLS, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
+  increment!(nls, :neval_jtprod_residual)
+  Jtv[1:2] .= [v[1] + v[2]; -v[1] + v[2] + v[3]]
+  return Jtv
+end
+
+function NLPModels.hess_structure_residual!(nls :: LLS, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  return rows, cols
+end
+
+function NLPModels.hess_coord_residual!(nls :: LLS, x :: AbstractVector, v :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_hess_residual)
+  return vals
+end
+
+function NLPModels.jth_hess_residual(nls :: LLS, x :: AbstractVector, j :: Int)
+  increment!(nls, :neval_jhess_residual)
+  return zeros(eltype(x), 2, 2)
+end
+
+function NLPModels.hprod_residual!(nls :: LLS, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
+  increment!(nls, :neval_hprod_residual)
+  Hiv[1:2] .= zero(eltype(x))
+  return Hiv
+end
+
+function NLPModels.cons!(nls :: LLS, x :: AbstractVector, cx :: AbstractVector)
+  increment!(nls, :neval_cons)
+  cx[1] = x[1] + x[2]
+  return cx
+end
+
+function NLPModels.jac_structure!(nls :: LLS, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1:2] .= [1, 1]
+  cols[1:2] .= [1, 2]
+  return rows, cols
+end
+
+function NLPModels.jac_coord!(nls :: LLS, x :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_jac)
+  T = eltype(x)
+  vals[1:2] .= T[1, 1]
+  return vals
+end
+
+function NLPModels.jprod!(nls :: LLS, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
+  increment!(nls, :neval_jprod)
+  Jv[1] = v[1] + v[2]
+  return Jv
+end
+
+function NLPModels.jtprod!(nls :: LLS, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
+  increment!(nls, :neval_jtprod)
+  Jtv[1:2] .= v
+  return Jtv
+end

--- a/test/nls_problems/mgh01.jl
+++ b/test/nls_problems/mgh01.jl
@@ -1,0 +1,146 @@
+using NLPModels: increment!
+
+function mgh01_autodiff()
+
+  x0 = [-1.2; 1.0]
+  F(x) = [10 * (x[2] - x[1]^2); 1 - x[1]]
+
+  return ADNLSModel(F, x0, 2)
+end
+
+mgh01_special() = FeasibilityResidual(MGH01Feas())
+
+mutable struct MGH01 <: AbstractNLSModel
+  meta :: NLPModelMeta
+  nls_meta :: NLSMeta
+  counters :: NLSCounters
+end
+
+function MGH01()
+  meta = NLPModelMeta(2, x0=[-1.2; 1.0], name="MGH01")
+  nls_meta = NLSMeta(2, 2, nnzj=3, nnzh=1)
+
+  return MGH01(meta, nls_meta, NLSCounters())
+end
+
+function NLPModels.residual!(nls :: MGH01, x :: AbstractVector, Fx :: AbstractVector)
+  increment!(nls, :neval_residual)
+  Fx[1:2] .= [10 * (x[2] - x[1]^2); 1 - x[1]]
+  return Fx
+end
+
+# Jx = [-20x₁  10;  -1  0]
+function NLPModels.jac_structure_residual!(nls :: MGH01, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1:3] .= [1, 1, 2]
+  cols[1:3] .= [1, 2, 1]
+  return rows, cols
+end
+
+function NLPModels.jac_coord_residual!(nls :: MGH01, x :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_jac_residual)
+  vals[1:3] .= [-20x[1], 10, -1]
+  return vals
+end
+
+function NLPModels.jprod_residual!(nls :: MGH01, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
+  increment!(nls, :neval_jprod_residual)
+  Jv[1:2] .= [-20x[1] * v[1] + 10v[2]; -v[1]]
+  return Jv
+end
+
+function NLPModels.jtprod_residual!(nls :: MGH01, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
+  increment!(nls, :neval_jtprod_residual)
+  Jtv[1:2] .= [-20x[1] * v[1] - v[2]; 10v[1]]
+  return Jtv
+end
+
+function NLPModels.hess_structure_residual!(nls :: MGH01, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1] = 1
+  cols[1] = 1
+  return rows, cols
+end
+
+function NLPModels.hess_coord_residual!(nls :: MGH01, x :: AbstractVector, v :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_hess_residual)
+  vals[1] = -20v[1]
+  return vals
+end
+
+function NLPModels.jth_hess_residual(nls :: MGH01, x :: AbstractVector, j :: Int)
+  increment!(nls, :neval_jhess_residual)
+  if j == 1
+    return eltype(x)[-20 0; 0 0]
+  else
+    return zeros(eltype(x), 2, 2)
+  end
+end
+
+function NLPModels.hprod_residual!(nls :: MGH01, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
+  increment!(nls, :neval_hprod_residual)
+  if i == 1
+    Hiv[1:2] .= [-20v[1]; 0]
+  else
+    Hiv[1:2] .= zero(eltype(x))
+  end
+  return Hiv
+end
+
+mutable struct MGH01Feas <: AbstractNLPModel
+  meta :: NLPModelMeta
+  counters :: Counters
+end
+
+function MGH01Feas()
+  meta = NLPModelMeta(2, x0=[-1.2; 1.0], name="MGH01Feas", ncon=2, lcon=zeros(2), ucon=zeros(2), nnzj=3, nnzh=1)
+
+  return MGH01Feas(meta, Counters())
+end
+
+function NLPModels.cons!(nls :: MGH01Feas, x :: AbstractVector, cx :: AbstractVector)
+  increment!(nls, :neval_cons)
+  cx[1:2] .= [10 * (x[2] - x[1]^2); 1 - x[1]]
+  return cx
+end
+
+# Jx = [-20x₁  10;  -1  0]
+function NLPModels.jac_structure!(nls :: MGH01Feas, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1:3] .= [1, 1, 2]
+  cols[1:3] .= [1, 2, 1]
+  return rows, cols
+end
+
+function NLPModels.jac_coord!(nls :: MGH01Feas, x :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_jac)
+  vals[1:3] .= [-20x[1], 10, -1]
+  return vals
+end
+
+function NLPModels.jprod!(nls :: MGH01Feas, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
+  increment!(nls, :neval_jprod)
+  Jv[1:2] .= [-20x[1] * v[1] + 10v[2]; -v[1]]
+  return Jv
+end
+
+function NLPModels.jtprod!(nls :: MGH01Feas, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
+  increment!(nls, :neval_jtprod)
+  Jtv[1:2] .= [-20x[1] * v[1] - v[2]; 10v[1]]
+  return Jtv
+end
+
+function NLPModels.hess_structure!(nls :: MGH01Feas, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1] = 1
+  cols[1] = 1
+  return rows, cols
+end
+
+function NLPModels.hess_coord!(nls :: MGH01Feas, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector; obj_weight::Float64=1.0)
+  increment!(nls, :neval_hess)
+  vals[1] = -20y[1]
+  return vals
+end
+
+function NLPModels.hprod!(nls :: MGH01Feas, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight::Float64=1.0)
+  increment!(nls, :neval_hprod)
+  Hv[1:2] .= [-20y[1] * v[1]; 0]
+  return Hv
+end

--- a/test/nls_problems/nlshs20.jl
+++ b/test/nls_problems/nlshs20.jl
@@ -1,0 +1,119 @@
+using NLPModels: increment!
+
+function nlshs20_autodiff()
+
+  x0 = [-2.0; 1.0]
+  F(x) = [10 * (x[2] - x[1]^2); 1 - x[1]]
+  lvar = [-0.5; -Inf]
+  uvar = [0.5; Inf]
+  c(x) = [x[1] + x[2]^2; x[1]^2 + x[2]; x[1]^2 + x[2]^2 - 1]
+  lcon = zeros(3)
+  ucon = fill(Inf, 3)
+
+  return ADNLSModel(F, x0, 2, lvar=lvar, uvar=uvar, c=c, lcon=lcon, ucon=ucon)
+end
+
+mutable struct NLSHS20 <: AbstractNLSModel
+  meta :: NLPModelMeta
+  nls_meta :: NLSMeta
+  counters :: NLSCounters
+end
+
+function NLSHS20()
+  meta = NLPModelMeta(2, x0=[-2.0; 1.0], name="NLSHS20", lvar=[-0.5; -Inf], uvar=[0.5; Inf], ncon=3, lcon=zeros(3), ucon=fill(Inf, 3), nnzj=6)
+  nls_meta = NLSMeta(2, 2, nnzj=3, nnzh=1)
+
+  return NLSHS20(meta, nls_meta, NLSCounters())
+end
+
+function NLPModels.residual!(nls :: NLSHS20, x :: AbstractVector, Fx :: AbstractVector)
+  increment!(nls, :neval_residual)
+  Fx[1:2] .= [10 * (x[2] - x[1]^2); 1 - x[1]]
+  return Fx
+end
+
+# Jx = [-20x₁  10;  -1  0]
+function NLPModels.jac_structure_residual!(nls :: NLSHS20, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1:3] .= [1, 1, 2]
+  cols[1:3] .= [1, 2, 1]
+  return rows, cols
+end
+
+function NLPModels.jac_coord_residual!(nls :: NLSHS20, x :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_jac_residual)
+  vals[1:3] .= [-20x[1], 10, -1]
+  return vals
+end
+
+function NLPModels.jprod_residual!(nls :: NLSHS20, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
+  increment!(nls, :neval_jprod_residual)
+  Jv[1:2] .= [-20x[1] * v[1] + 10v[2]; -v[1]]
+  return Jv
+end
+
+function NLPModels.jtprod_residual!(nls :: NLSHS20, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
+  increment!(nls, :neval_jtprod_residual)
+  Jtv[1:2] .= [-20x[1] * v[1] - v[2]; 10v[1]]
+  return Jtv
+end
+
+function NLPModels.hess_structure_residual!(nls :: NLSHS20, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1] = 1
+  cols[1] = 1
+  return rows, cols
+end
+
+function NLPModels.hess_coord_residual!(nls :: NLSHS20, x :: AbstractVector, v :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_hess_residual)
+  vals[1] = -20v[1]
+  return vals
+end
+
+function NLPModels.jth_hess_residual(nls :: NLSHS20, x :: AbstractVector, j :: Int)
+  increment!(nls, :neval_jhess_residual)
+  if j == 1
+    return eltype(x)[-20 0; 0 0]
+  else
+    return zeros(eltype(x), 2, 2)
+  end
+end
+
+function NLPModels.hprod_residual!(nls :: NLSHS20, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
+  increment!(nls, :neval_hprod_residual)
+  if i == 1
+    Hiv[1:2] .= [-20v[1]; 0]
+  else
+    Hiv[1:2] .= zero(eltype(x))
+  end
+  return Hiv
+end
+
+function NLPModels.cons!(nls :: NLSHS20, x :: AbstractVector, cx :: AbstractVector)
+  increment!(nls, :neval_cons)
+  cx[1:3] .= [x[1] + x[2]^2; x[1]^2 + x[2]; x[1]^2 + x[2]^2 - 1]
+  return cx
+end
+
+function NLPModels.jac_structure!(nls :: NLSHS20, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
+  rows[1:6] .= [1, 1, 2, 2, 3, 3]
+  cols[1:6] .= [1, 2, 1, 2, 1, 2]
+  return rows, cols
+end
+
+function NLPModels.jac_coord!(nls :: NLSHS20, x :: AbstractVector, vals :: AbstractVector)
+  increment!(nls, :neval_jac)
+  vals[1:6] .= [1, 2x[2], 2x[1], 1, 2x[1], 2x[2]]
+  return vals
+end
+
+function NLPModels.jprod!(nls :: NLSHS20, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
+  increment!(nls, :neval_jprod)
+  Jv[1:3] .= [v[1] + 2x[2] * v[2]; 2x[1] * v[1] + v[2]; 2x[1] * v[1] + 2x[2] * v[2]]
+  return Jv
+end
+
+function NLPModels.jtprod!(nls :: NLSHS20, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
+  increment!(nls, :neval_jtprod)
+  Jtv[1:2] .= [v[1] + 2x[1] * (v[2] + v[3]); v[2] + 2x[2] * (v[1] + v[3])]
+  return Jtv
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,7 +76,20 @@ end
 include("test_autodiff_model.jl")
 include("test_nlsmodels.jl")
 include("nls_consistency.jl")
-consistent_nls()
+for problem in ["LLS", "MGH01", "NLSHS20"]
+  include("nls_problems/$(lowercase(problem)).jl")
+  @printf("Checking problem %-20s", problem)
+  nls_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
+  nls_man = eval(Meta.parse(problem))()
+
+  nlss = [nls_ad, nls_man]
+  spc = lowercase(problem) * "_special"
+  if isdefined(Main, Symbol(spc))
+    push!(nlss, eval(Meta.parse(spc))())
+  end
+  consistent_nlss(nlss)
+  println("✓")
+end
 include("test_feasibility_form_nls.jl")
 include("multiple-precision.jl")
 include("test_view_subarray.jl")


### PR DESCRIPTION
Instead of defining problems inside nls_consistency.jl, define problems
inside files the same way the general consistency works. This allows
other packages to reuse these problems. It's also cleaner.