### PR TITLE
In test-breakage, after removal, dev has to be run again

### DIFF
--- a/test/test-breakage.jl
+++ b/test/test-breakage.jl
@@ -60,7 +60,9 @@ function test_breakage()
         tag = split(Git.readstring(`tag`))[end]
         tagged[i] = tag
         Git.run(`checkout $tag`)
-        pkg"up"
+        pkg"activate ."
+        pkg"instantiate"
+        pkg"dev ../.."
         pkg"build"
         pkg"test"
         passing[i] = true


### PR DESCRIPTION
I thought I fixed it, but it actually runs on a released version, not the PR.