### PR TITLE
Test-breakage runs in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,53 @@ branches:
 
 jobs:
   include:
-    - stage: Breakage
+    - &breakage
+      stage: Breakage
       julia: 1.3
       os: linux
       if: type = pull_request
+      script:
+        - julia -e 'using Pkg; pkg"add Git"; pkg"add JSON"; include("test/test-breakage.jl")'
+      after_success: skip
+      env: PKG=AmplNLReader     VERSION=master
+    - <<: *breakage
+      env: PKG=AmplNLReader     VERSION=stable
+    - <<: *breakage
+      env: PKG=CUTEst           VERSION=master
       addons:
         apt_packages:
           - gfortran
+    - <<: *breakage
+      env: PKG=CUTEst           VERSION=stable
+      addons:
+        apt_packages:
+          - gfortran
+    - <<: *breakage
+      env: PKG=CaNNOLeS         VERSION=master
+    - <<: *breakage
+      env: PKG=CaNNOLeS         VERSION=stable
+    - <<: *breakage
+      env: PKG=NLPModelsIpopt   VERSION=master
+    - <<: *breakage
+      env: PKG=NLPModelsIpopt   VERSION=stable
+    - <<: *breakage
+      env: PKG=NLPModelsJuMP    VERSION=master
+    - <<: *breakage
+      env: PKG=NLPModelsJuMP    VERSION=stable
+    - <<: *breakage
+      env: PKG=QuadraticModels  VERSION=master
+    - <<: *breakage
+      env: PKG=QuadraticModels  VERSION=stable
+    - <<: *breakage
+      env: PKG=SolverTools      VERSION=master
+    - <<: *breakage
+      env: PKG=SolverTools      VERSION=stable
+    - stage: "Breakage Deploy"
+      julia: 1.3
+      os: linux
+      if: type = pull_request
       script:
-        - julia -e 'using Pkg; pkg"add Git"; pkg"add GitHub"; include("test/test-breakage.jl")'
+        - julia -e 'using Pkg; pkg"add Git"; pkg"add GitHub"; pkg"add JSON"; include("test/test-breakage-deploy.jl")'
       after_success: skip
     - stage: Documentation
       julia: 1.3
@@ -50,6 +88,4 @@ jobs:
 after_success:
   - julia -e 'if Sys.islinux() && string(VERSION)[1:3] == "1.3"
       using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())
-    else
-      println("Coverage skipped")
     end'

--- a/test/test-breakage-deploy.jl
+++ b/test/test-breakage-deploy.jl
@@ -1,0 +1,60 @@
+using Git, GitHub, JSON, Pkg
+
+"""
+    test_breakage_deploy()
+
+Read files from breakage-info and publish to the PR
+"""
+function test_breakage_deploy()
+  if lowercase(get(ENV, "TRAVIS", "false")) == "false"
+    error("Only run in travis")
+  end
+  if get(ENV, "GITHUB_AUTH", nothing) === nothing
+    error("GITHUB_AUTH not found")
+  end
+  key = ENV["GITHUB_AUTH"]
+  repo = ENV["TRAVIS_REPO_SLUG"]
+  user = split(repo, "/")[1]
+  upstream = "https://$user:$key@github.com/$repo"
+  Git.run(`remote add upstream $upstream`)
+  Git.run(`fetch upstream`)
+  Git.run(`checkout -f breakage-info`)
+
+  badge_pass(x) = "![](https://img.shields.io/badge/$x-Pass-green)"
+  badge_fail(x) = "![](https://img.shields.io/badge/$x-Fail-red)"
+  badge(tf, x) = tf ? badge_pass(x) : badge_fail(x)
+
+  packages = ["AmplNLReader", "CUTEst", "CaNNOLeS", "NLPModelsIpopt", "NLPModelsJuMP", "QuadraticModels", "SolverTools"]
+
+  output = ":robot: Testing breakage of this pull request\n\n"
+  output *= "| Package Name | master | stable |\n"
+  output *= "|--|--|--|\n"
+  for package in packages
+    output *= "| $package | "
+
+    for version in ["master", "stable"]
+      info = JSON.parse(open("$package-$version"))
+      bdg = badge(info["pass"], info["tag"])
+      url = info["travis_link"]
+      output *= "[$bdg]($url) | "
+    end
+    output *= "\n"
+  end
+
+  println(output)
+
+  myauth = GitHub.authenticate(key)
+  myrepo = GitHub.repo(ENV["TRAVIS_PULL_REQUEST_SLUG"], auth=myauth) # "JuliaSmoothOptimizers/NLPModels.jl"
+  prs = pull_requests(myrepo, auth=myauth)
+  pr = nothing
+  for p in prs[1]
+    if p.merge_commit_sha == ENV["TRAVIS_COMMIT"]
+      pr = p
+    end
+  end
+  @assert pr != nothing
+
+  GitHub.create_comment(GitHub.DEFAULT_API, myrepo, pr, :pr, auth=myauth, params=Dict(:body => output))
+end
+
+test_breakage_deploy()


### PR DESCRIPTION
Supercedes #232 

- This split the test-breakage into one test for each pkg/version, i.e., 14 parallel tests (not really, because there is a limit for free users, but better than the alternative);
- Each test pushes a commit to a branch `breakage-info` with its own information;
- An additional stage reads the branch and creates the report.

Closes #232