### PR TITLE
Refactor multiple precision tests and fix some multiple precision issues

### DIFF
--- a/test/problems/hs10.jl
+++ b/test/problems/hs10.jl
@@ -5,7 +5,7 @@ function hs10_autodiff()
 
   x0 = [-10.0; 10.0]
   f(x) = x[1] - x[2]
-  c(x) = [-3 * x[1]^2 + 2 * x[1] * x[2] - x[2]^2 + 1.0]
+  c(x) = [-3 * x[1]^2 + 2 * x[1] * x[2] - x[2]^2 + 1]
   lcon = [0.0]
   ucon = [Inf]
 
@@ -29,20 +29,20 @@ function NLPModels.obj(nlp :: HS10, x :: AbstractVector)
   return x[1] - x[2]
 end
 
-function NLPModels.grad!(nlp :: HS10, x :: AbstractVector, gx :: AbstractVector)
+function NLPModels.grad!(nlp :: HS10, x :: AbstractVector{T}, gx :: AbstractVector{T}) where T
   increment!(nlp, :neval_grad)
-  gx .= [1.0; -1.0]
+  gx .= T[1; -1]
   return gx
 end
 
-function NLPModels.hess(nlp :: HS10, x :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS10, x :: AbstractVector{T}; obj_weight=1.0) where T
   increment!(nlp, :neval_hess)
-  return spzeros(2, 2)
+  return spzeros(T, 2, 2)
 end
 
-function NLPModels.hess(nlp :: HS10, x :: AbstractVector, y :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS10, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=1.0) where T
   increment!(nlp, :neval_hess)
-  return y[1] * [-6.0  0.0; 2.0  -2.0]
+  return y[1] * T[-6.0  0.0; 2.0  -2.0]
 end
 
 function NLPModels.hess_structure!(nlp :: HS10, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -51,33 +51,33 @@ function NLPModels.hess_structure!(nlp :: HS10, rows :: AbstractVector{Int}, col
   return rows, cols
 end
 
-function NLPModels.hess_coord!(nlp :: HS10, x :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS10, x :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=1.0) where T
   increment!(nlp, :neval_hess)
-  vals .= 0.0
+  vals .= zero(T)
   return vals
 end
 
-function NLPModels.hess_coord!(nlp :: HS10, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS10, x :: AbstractVector{T}, y :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=1.0) where T
   increment!(nlp, :neval_hess)
-  vals .= [-6.0, 2.0, -2.0] * y[1]
+  vals .= T[-6, 2, -2] * y[1]
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS10, x :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS10, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=1.0) where T
   increment!(nlp, :neval_hprod)
-  fill!(Hv, 0.0)
+  fill!(Hv, zero(T))
   return Hv
 end
 
 function NLPModels.hprod!(nlp :: HS10, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
   increment!(nlp, :neval_hprod)
-  Hv[1:nlp.meta.nvar] .= y[1] * [-6.0 * v[1] + 2.0 * v[2]; 2.0 * v[1] - 2.0 * v[2]]
+  Hv[1:nlp.meta.nvar] .= y[1] * [-6 * v[1] + 2 * v[2]; 2 * v[1] - 2 * v[2]]
   return Hv
 end
 
 function NLPModels.cons!(nlp :: HS10, x :: AbstractVector, cx :: AbstractVector)
   increment!(nlp, :neval_cons)
-  cx .= [-3 * x[1]^2 + 2 * x[1] * x[2] - x[2]^2 + 1.0]
+  cx .= [-3 * x[1]^2 + 2 * x[1] * x[2] - x[2]^2 + 1]
   return cx
 end
 

--- a/test/problems/hs11.jl
+++ b/test/problems/hs11.jl
@@ -33,14 +33,14 @@ function NLPModels.grad!(nlp :: HS11, x :: AbstractVector, gx :: AbstractVector)
   return gx
 end
 
-function NLPModels.hess(nlp :: HS11, x :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS11, x :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  return [2.0 0; 0 2] * obj_weight
+  return T[2 0; 0 2] * obj_weight
 end
 
-function NLPModels.hess(nlp :: HS11, x :: AbstractVector, y :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS11, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  return y[1] * [-2.0 0; 0 0] + 2obj_weight*I
+  return y[1] * T[-2 0; 0 0] + 2obj_weight*I
 end
 
 function NLPModels.hess_structure!(nlp :: HS11, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -49,26 +49,26 @@ function NLPModels.hess_structure!(nlp :: HS11, rows :: AbstractVector{Int}, col
   return rows, cols
 end
 
-function NLPModels.hess_coord!(nlp :: HS11, x :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS11, x :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
   vals .= 2obj_weight
   return vals
 end
 
-function NLPModels.hess_coord!(nlp :: HS11, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS11, x :: AbstractVector{T}, y :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
   vals .= 2obj_weight
   vals[1] -= 2y[1]
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS11, x :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS11, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
   Hv .= 2obj_weight * v
   return Hv
 end
 
-function NLPModels.hprod!(nlp :: HS11, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS11, x :: AbstractVector{T}, y :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
   Hv .= 2obj_weight * v
   Hv[1] -= 2y[1] * v[1]
@@ -83,7 +83,7 @@ end
 
 function NLPModels.jac(nlp :: HS11, x :: AbstractVector)
   increment!(nlp, :neval_jac)
-  return [-2 * x[1]  1.0]
+  return [-2 * x[1]  1]
 end
 
 function NLPModels.jac_structure!(nlp :: HS11, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -94,7 +94,7 @@ end
 
 function NLPModels.jac_coord!(nlp :: HS11, x :: AbstractVector, vals :: AbstractVector)
   increment!(nlp, :neval_jac)
-  vals .= [-2 * x[1], 1.0]
+  vals .= [-2 * x[1], 1]
   return vals
 end
 
@@ -106,6 +106,6 @@ end
 
 function NLPModels.jtprod!(nlp :: HS11, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
   increment!(nlp, :neval_jtprod)
-  Jtv .= [-2 * x[1]; 1.0] * v[1]
+  Jtv .= [-2 * x[1]; 1] * v[1]
   return Jtv
 end

--- a/test/problems/hs14.jl
+++ b/test/problems/hs14.jl
@@ -32,14 +32,14 @@ function NLPModels.grad!(nlp :: HS14, x :: AbstractVector, gx :: AbstractVector)
   return gx
 end
 
-function NLPModels.hess(nlp :: HS14, x :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS14, x :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  return [2.0 0; 0 2] * obj_weight
+  return T[2 0; 0 2] * obj_weight
 end
 
-function NLPModels.hess(nlp :: HS14, x :: AbstractVector, y :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS14, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  return y[2] * [-0.5 0.0; 0.0 -2.0] + 2obj_weight * I
+  return y[2] * T[-0.5 0.0; 0.0 -2.0] + 2obj_weight * I
 end
 
 function NLPModels.hess_structure!(nlp :: HS14, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -48,30 +48,30 @@ function NLPModels.hess_structure!(nlp :: HS14, rows :: AbstractVector{Int}, col
   return rows, cols
 end
 
-function NLPModels.hess_coord!(nlp :: HS14, x :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS14, x :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
   vals .= 2obj_weight
   return vals
 end
 
-function NLPModels.hess_coord!(nlp :: HS14, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS14, x :: AbstractVector{T}, y :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
   vals .= 2obj_weight
-  vals[1] -= 0.5y[2]
-  vals[2] -= 2.0y[2]
+  vals[1] -= y[2] / 2
+  vals[2] -= 2y[2]
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS14, x :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS14, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
   Hv .= 2obj_weight * v
   return Hv
 end
 
-function NLPModels.hprod!(nlp :: HS14, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS14, x :: AbstractVector{T}, y :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
   Hv .= 2obj_weight * v
-  Hv[1] -= 0.5y[2] * v[1]
+  Hv[1] -= y[2] * v[1] / 2
   Hv[2] -= 2y[2] * v[2]
   return Hv
 end
@@ -84,7 +84,7 @@ end
 
 function NLPModels.jac(nlp :: HS14, x :: AbstractVector)
   increment!(nlp, :neval_jac)
-  return [1.0 -2.0; -x[1] / 2  -2 * x[2]]
+  return [1 -2; -x[1] / 2  -2 * x[2]]
 end
 
 function NLPModels.jac_structure!(nlp :: HS14, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -95,7 +95,7 @@ end
 
 function NLPModels.jac_coord!(nlp :: HS14, x :: AbstractVector, vals :: AbstractVector)
   increment!(nlp, :neval_jac)
-  vals .= [1.0, -x[1] / 2, -2.0, -2 * x[2]]
+  vals .= [1, -x[1] / 2, -2, -2 * x[2]]
   return vals
 end
 

--- a/test/problems/hs5.jl
+++ b/test/problems/hs5.jl
@@ -4,7 +4,7 @@ using NLPModels: increment!
 function hs5_autodiff()
 
   x0 = [0.0; 0.0]
-  f(x) = sin(x[1] + x[2]) + (x[1] - x[2])^2 - 1.5 * x[1] + 2.5 * x[2] + 1
+  f(x) = sin(x[1] + x[2]) + (x[1] - x[2])^2 - 3x[1] / 2 + 5x[2] / 2 + 1
   l = [-1.5; -3.0]
   u = [4.0; 3.0]
 
@@ -24,18 +24,18 @@ end
 
 function NLPModels.obj(nlp :: HS5, x :: AbstractVector)
   increment!(nlp, :neval_obj)
-  return sin(x[1] + x[2]) + (x[1] - x[2])^2 - 1.5 * x[1] + 2.5 * x[2] + 1
+  return sin(x[1] + x[2]) + (x[1] - x[2])^2 - 3x[1] / 2 + 5x[2] / 2 + 1
 end
 
-function NLPModels.grad!(nlp :: HS5, x :: AbstractVector, gx :: AbstractVector)
+function NLPModels.grad!(nlp :: HS5, x :: AbstractVector{T}, gx :: AbstractVector{T}) where T
   increment!(nlp, :neval_grad)
-  gx .= cos(x[1] + x[2]) * ones(2) + 2 * (x[1] - x[2]) * [1.0; -1.0] + [-1.5; 2.5]
+  gx .= cos(x[1] + x[2]) * ones(T, 2) + 2 * (x[1] - x[2]) * T[1; -1] + T[-1.5; 2.5]
   return gx
 end
 
-function NLPModels.hess(nlp :: HS5, x :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS5, x :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  return tril(-sin(x[1] + x[2])*ones(2, 2) + [2.0 -2.0; -2.0 2.0]) * obj_weight
+  return tril(-sin(x[1] + x[2])*ones(T, 2, 2) + T[2 -2; -2 2]) * obj_weight
 end
 
 function NLPModels.hess_structure!(nlp :: HS5, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -53,8 +53,8 @@ function NLPModels.hess_coord!(nlp :: HS5, x :: AbstractVector, vals :: Abstract
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS5, x :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS5, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
-  Hv .= (- sin(x[1] + x[2]) * (v[1] + v[2]) * ones(2) + 2 * [v[1] - v[2]; v[2] - v[1]]) * obj_weight
+  Hv .= (- sin(x[1] + x[2]) * (v[1] + v[2]) * ones(T, 2) + 2 * [v[1] - v[2]; v[2] - v[1]]) * obj_weight
   return Hv
 end

--- a/test/problems/hs6.jl
+++ b/test/problems/hs6.jl
@@ -29,18 +29,18 @@ end
 
 function NLPModels.grad!(nlp :: HS6, x :: AbstractVector, gx :: AbstractVector)
   increment!(nlp, :neval_grad)
-  gx .= [2 * (x[1] - 1); 0.0]
+  gx .= [2 * (x[1] - 1); 0]
   return gx
 end
 
-function NLPModels.hess(nlp :: HS6, x :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS6, x :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  return [2.0 * obj_weight  0.0; 0.0 0.0]
+  return [2obj_weight  0; 0 0]
 end
 
-function NLPModels.hess(nlp :: HS6, x :: AbstractVector, y :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess(nlp :: HS6, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  return [2.0 * obj_weight - 20 * y[1]   0.0; 0.0 0.0]
+  return [2obj_weight - 20y[1]   0; 0 0]
 end
 
 function NLPModels.hess_structure!(nlp :: HS6, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -49,27 +49,27 @@ function NLPModels.hess_structure!(nlp :: HS6, rows :: AbstractVector{Int}, cols
   return rows, cols
 end
 
-function NLPModels.hess_coord!(nlp :: HS6, x :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS6, x :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  vals[1] = 2.0 * obj_weight
+  vals[1] = 2obj_weight
   return vals
 end
 
-function NLPModels.hess_coord!(nlp :: HS6, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
+function NLPModels.hess_coord!(nlp :: HS6, x :: AbstractVector{T}, y :: AbstractVector{T}, vals :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hess)
-  vals[1] = 2.0 * obj_weight - 20 * y[1]
+  vals[1] = 2obj_weight - 20y[1]
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS6, x :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS6, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
-  Hv .= [2.0 * obj_weight * v[1]; 0.0]
+  Hv .= [2obj_weight * v[1]; 0]
   return Hv
 end
 
-function NLPModels.hprod!(nlp :: HS6, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
+function NLPModels.hprod!(nlp :: HS6, x :: AbstractVector{T}, y :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
-  Hv .= [(2.0 * obj_weight - 20 * y[1]) * v[1]; 0.0]
+  Hv .= [(2obj_weight - 20y[1]) * v[1]; 0]
   return Hv
 end
 
@@ -81,7 +81,7 @@ end
 
 function NLPModels.jac(nlp :: HS6, x :: AbstractVector)
   increment!(nlp, :neval_jac)
-  return [-20 * x[1]  10.0]
+  return [-20 * x[1]  10]
 end
 
 function NLPModels.jac_structure!(nlp :: HS6, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
@@ -93,7 +93,7 @@ end
 function NLPModels.jac_coord!(nlp :: HS6, x :: AbstractVector, vals :: AbstractVector)
   increment!(nlp, :neval_jac)
   vals[1] = -20 * x[1]
-  vals[2] = 10.0
+  vals[2] = 10
   return vals
 end
 

--- a/test/test-breakage-deploy.jl
+++ b/test/test-breakage-deploy.jl
@@ -48,7 +48,7 @@ function test_breakage_deploy()
   prs = pull_requests(myrepo, auth=myauth)
   pr = nothing
   for p in prs[1]
-    if p.merge_commit_sha == ENV["TRAVIS_COMMIT"]
+    if p.number == Meta.parse(ENV["TRAVIS_PULL_REQUEST"])
       pr = p
     end
   end


### PR DESCRIPTION
Multiple precision is tested through a function now, so it tests an input problem,  instead of a fixed ADNLPModel. This allows the multiple precision tests to be used in other packages. Also run multiple precision tests in more models.