### PR TITLE
Define getproperty so that nlp.X = nlp.meta.X

### DIFF
--- a/src/NLSModels.jl
+++ b/src/NLSModels.jl
@@ -96,7 +96,7 @@ include("feasibility_residual.jl")
 Computes F(x), the residual at x.
 """
 function residual(nls :: AbstractNLSModel, x :: AbstractVector)
-  Fx = zeros(eltype(x), nls_meta(nls).nequ)
+  Fx = zeros(eltype(x), nls.nls_nequ)
   residual!(nls, x, Fx)
 end
 
@@ -117,7 +117,7 @@ Computes J(x), the Jacobian of the residual at x.
 function jac_residual(nls :: AbstractNLSModel, x :: AbstractVector)
   rows, cols = jac_structure_residual(nls)
   vals = jac_coord_residual(nls, x)
-  sparse(rows, cols, vals, nls.nls_meta.nequ, nls.meta.nvar)
+  sparse(rows, cols, vals, nls.nls_nequ, nls.nvar)
 end
 
 """
@@ -135,8 +135,8 @@ end
 Returns the structure of the constraint's Jacobian in sparse coordinate format.
 """
 function jac_structure_residual(nls :: AbstractNLSModel)
-  rows = Vector{Int}(undef, nls.nls_meta.nnzj)
-  cols = Vector{Int}(undef, nls.nls_meta.nnzj)
+  rows = Vector{Int}(undef, nls.nls_nnzj)
+  cols = Vector{Int}(undef, nls.nls_nnzj)
   jac_structure_residual!(nls, rows, cols)
 end
 
@@ -156,7 +156,7 @@ end
 Computes the Jacobian of the residual at `x` in sparse coordinate format.
 """
 function jac_coord_residual(nls :: AbstractNLSModel, x :: AbstractVector)
-  vals = Vector{eltype(x)}(undef, nls.nls_meta.nnzj)
+  vals = Vector{eltype(x)}(undef, nls.nls_nnzj)
   jac_coord_residual!(nls, x, vals)
 end
 
@@ -166,7 +166,7 @@ end
 Computes the product of the Jacobian of the residual at x and a vector, i.e.,  J(x)*v.
 """
 function jprod_residual(nls :: AbstractNLSModel, x :: AbstractVector, v :: AbstractVector)
-  Jv = zeros(eltype(x), nls_meta(nls).nequ)
+  Jv = zeros(eltype(x), nls.nls_nequ)
   jprod_residual!(nls, x, v, Jv)
 end
 
@@ -185,7 +185,7 @@ end
 Computes the product of the transpose of the Jacobian of the residual at x and a vector, i.e.,  J(x)'*v.
 """
 function jtprod_residual(nls :: AbstractNLSModel, x :: AbstractVector, v :: AbstractVector)
-  Jtv = zeros(eltype(x), nls_meta(nls).nvar)
+  Jtv = zeros(eltype(x), nls.nvar)
   jtprod_residual!(nls, x, v, Jtv)
 end
 
@@ -206,7 +206,7 @@ Computes J(x), the Jacobian of the residual at x, in linear operator form.
 function jac_op_residual(nls :: AbstractNLSModel, x :: AbstractVector)
   prod = @closure v -> jprod_residual(nls, x, v)
   ctprod = @closure v -> jtprod_residual(nls, x, v)
-  return LinearOperator{Float64}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+  return LinearOperator{Float64}(nls.nls_nequ, nls.nvar,
                                  false, false, prod, ctprod, ctprod)
 end
 
@@ -220,7 +220,7 @@ function jac_op_residual!(nls :: AbstractNLSModel, x :: AbstractVector,
                           Jv :: AbstractVector, Jtv :: AbstractVector)
   prod = @closure v -> jprod_residual!(nls, x, v, Jv)
   ctprod = @closure v -> jtprod_residual!(nls, x, v, Jtv)
-  return LinearOperator{Float64}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+  return LinearOperator{Float64}(nls.nls_nequ, nls.nvar,
                                  false, false, prod, ctprod, ctprod)
 end
 
@@ -233,7 +233,7 @@ Computes the linear combination of the Hessians of the residuals at `x` with coe
 function hess_residual(nls :: AbstractNLSModel, x :: AbstractVector, v :: AbstractVector)
   rows, cols = hess_structure_residual(nls)
   vals = hess_coord_residual(nls, x, v)
-  sparse(rows, cols, vals, nls.meta.nvar, nls.meta.nvar)
+  sparse(rows, cols, vals, nls.nvar, nls.nvar)
 end
 
 """
@@ -242,8 +242,8 @@ end
 Returns the structure of the residual Hessian.
 """
 function hess_structure_residual(nls :: AbstractNLSModel)
-  rows = Vector{Int}(undef, nls.nls_meta.nnzh)
-  cols = Vector{Int}(undef, nls.nls_meta.nnzh)
+  rows = Vector{Int}(undef, nls.nls_nnzh)
+  cols = Vector{Int}(undef, nls.nls_nnzh)
   hess_structure_residual!(nls, rows, cols)
 end
 
@@ -273,7 +273,7 @@ Computes the linear combination of the Hessians of the residuals at `x` with coe
 `v` in sparse coordinate format.
 """
 function hess_coord_residual(nls :: AbstractNLSModel, x :: AbstractVector, v :: AbstractVector)
-  vals = Vector{eltype(x)}(undef, nls.nls_meta.nnzh)
+  vals = Vector{eltype(x)}(undef, nls.nls_nnzh)
   hess_coord_residual!(nls, x, v, vals)
 end
 
@@ -292,7 +292,7 @@ end
 Computes the product of the Hessian of the i-th residual at x, times the vector v.
 """
 function hprod_residual(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int, v :: AbstractVector)
-  Hv = zeros(eltype(x), nls_meta(nls).nvar)
+  Hv = zeros(eltype(x), nls.nvar)
   hprod_residual!(nls, x, i, v, Hv)
 end
 
@@ -312,7 +312,7 @@ Computes the Hessian of the i-th residual at x, in linear operator form.
 """
 function hess_op_residual(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int)
   prod = @closure v -> hprod_residual(nls, x, i, v)
-  return LinearOperator{Float64}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+  return LinearOperator{Float64}(nls.nvar, nls.nvar,
                                  true, true, prod, prod, prod)
 end
 
@@ -323,7 +323,7 @@ Computes the Hessian of the i-th residual at x, in linear operator form. The vec
 """
 function hess_op_residual!(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int, Hiv :: AbstractVector)
   prod = @closure v -> hprod_residual!(nls, x, i, v, Hiv)
-  return LinearOperator{Float64}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+  return LinearOperator{Float64}(nls.nvar, nls.nvar,
                                  true, true, prod, prod, prod)
 end
 

--- a/src/lls_model.jl
+++ b/src/lls_model.jl
@@ -140,7 +140,7 @@ end
 
 function cons!(nls :: LLSModel, x :: AbstractVector, c :: AbstractVector)
   increment!(nls, :neval_cons)
-  c[1:nls.meta.ncon] = nls.C * x
+  c[1:nls.ncon] = nls.C * x
   return c
 end
 
@@ -181,13 +181,13 @@ end
 
 function jprod!(nls :: LLSModel, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
   increment!(nls, :neval_jprod)
-  Jv[1:nls.meta.ncon] = nls.C * v
+  Jv[1:nls.ncon] = nls.C * v
   return Jv
 end
 
 function jtprod!(nls :: LLSModel, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
   increment!(nls, :neval_jtprod)
-  Jtv[1:nls.meta.nvar] = nls.C' * v
+  Jtv[1:nls.nvar] = nls.C' * v
   return Jtv
 end
 

--- a/src/nlp_types.jl
+++ b/src/nlp_types.jl
@@ -169,6 +169,14 @@ struct NLPModelMeta <: AbstractNLPModelMeta
   end
 end
 
+# Define nlp.X = nlp.X
+function Base.getproperty(nlp :: AbstractNLPModel, f :: Symbol)
+  if f in fieldnames(NLPModelMeta)
+    return getproperty(nlp.meta, f)
+  end
+  return getfield(nlp, f)
+end
+
 # Displaying NLPModelMeta instances.
 
 import Base.show, Base.print, Base.println

--- a/src/nls_meta.jl
+++ b/src/nls_meta.jl
@@ -25,3 +25,15 @@ function NLSMeta(nequ :: Int, nvar :: Int;
   nnzh = max(0, nnzh)
   return NLSMeta(nequ, nvar, x0, nnzj, nnzh)
 end
+
+const nls_fields = Dict(Symbol("nls_$x") => x for x in fieldnames(NLSMeta))
+
+function Base.getproperty(nls :: AbstractNLSModel, f :: Symbol)
+  if f in keys(nls_fields)
+    return getproperty(nls.nls_meta, nls_fields[f])
+  end
+  if f in fieldnames(NLPModelMeta)
+    return getproperty(nls.meta, f)
+  end
+  return getfield(nls, f)
+end

--- a/src/qn_model.jl
+++ b/src/qn_model.jl
@@ -16,13 +16,13 @@ end
 
 "Construct a `LBFGSModel` from another type of model."
 function LBFGSModel(nlp :: AbstractNLPModel; memory :: Int=5)
-  op = LBFGSOperator(nlp.meta.nvar, memory)
+  op = LBFGSOperator(nlp.nvar, memory)
   return LBFGSModel(nlp.meta, nlp, op)
 end
 
 "Construct a `LSR1Model` from another type of nlp."
 function LSR1Model(nlp :: AbstractNLPModel; memory :: Int=5)
-  op = LSR1Operator(nlp.meta.nvar, memory)
+  op = LSR1Operator(nlp.nvar, memory)
   return LSR1Model(nlp.meta, nlp, op)
 end
 
@@ -65,7 +65,7 @@ hess_op(nlp :: QuasiNewtonModel, x :: AbstractVector; kwargs...) = nlp.op
 hprod(nlp :: QuasiNewtonModel, x :: AbstractVector, v :: AbstractVector; kwargs...) = nlp.op * v
 function hprod!(nlp :: QuasiNewtonModel, x :: AbstractVector,
                 v :: AbstractVector, Hv :: AbstractVector; kwargs...)
-  Hv[1:nlp.meta.nvar] .= nlp.op * v
+  Hv[1:nlp.nvar] .= nlp.op * v
   return Hv
 end
 

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -91,8 +91,8 @@ function slack_meta(meta :: NLPModelMeta; name=meta.name * "-slack")
 end
 
 "Construct a `SlackModel` from another type of model."
-function SlackModel(model :: AbstractNLPModel; name=model.meta.name * "-slack")
-  model.meta.ncon == length(model.meta.jfix) && return model
+function SlackModel(model :: AbstractNLPModel; name=model.name * "-slack")
+  model.ncon == length(model.jfix) && return model
 
   meta = slack_meta(model.meta, name=name)
 
@@ -102,16 +102,16 @@ function SlackModel(model :: AbstractNLPModel; name=model.meta.name * "-slack")
   return snlp
 end
 
-function SlackNLSModel(model :: AbstractNLSModel; name=model.meta.name * "-slack")
-  ns = model.meta.ncon - length(model.meta.jfix)
+function SlackNLSModel(model :: AbstractNLSModel; name=model.name * "-slack")
+  ns = model.ncon - length(model.jfix)
   ns == 0 && return model
 
   meta = slack_meta(model.meta, name=name)
-  nls_meta = NLSMeta(model.nls_meta.nequ,
-                     model.meta.nvar + ns,
-                     x0=[model.meta.x0; zeros(eltype(model.meta.x0), ns)],
-                     nnzj=model.nls_meta.nnzj,
-                     nnzh=model.nls_meta.nnzh
+  nls_meta = NLSMeta(model.nls_nequ,
+                     model.nvar + ns,
+                     x0=[model.x0; zeros(eltype(model.x0), ns)],
+                     nnzj=model.nls_nnzj,
+                     nnzh=model.nls_nnzh
                     )
 
   snls = SlackNLSModel(meta, nls_meta, model)
@@ -157,84 +157,84 @@ end
 
 function obj(nlp :: SlackModels, x :: AbstractVector)
   # f(X) = f(x)
-  return obj(nlp.model, @view x[1:nlp.model.meta.nvar])
+  return obj(nlp.model, @view x[1:nlp.model.nvar])
 end
 
 function grad!(nlp :: SlackModels, x :: AbstractVector, g :: AbstractVector)
   # ∇f(X) = [∇f(x) ; 0]
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   @views grad!(nlp.model, x[1:n], g[1:n])
   g[n+1:n+ns] .= 0
   return g
 end
 
 function objgrad!(nlp :: SlackModels, x :: Array{Float64}, g :: Array{Float64})
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   @views f, _ = objgrad!(nlp.model, x[1:n], g[1:n])
   g[n+1:n+ns] .= 0
   return f, g
 end
 
 function cons!(nlp :: SlackModels, x :: AbstractVector, c :: AbstractVector)
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
-  nlow = length(nlp.model.meta.jlow)
-  nupp = length(nlp.model.meta.jupp)
-  nrng = length(nlp.model.meta.jrng)
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
+  nlow = length(nlp.model.jlow)
+  nupp = length(nlp.model.jupp)
+  nrng = length(nlp.model.jrng)
   @views begin
     cons!(nlp.model, x[1:n], c)
-    c[nlp.model.meta.jlow] -= x[n+1:n+nlow]
-    c[nlp.model.meta.jupp] -= x[n+nlow+1:n+nlow+nupp]
-    c[nlp.model.meta.jrng] -= x[n+nlow+nupp+1:n+nlow+nupp+nrng]
+    c[nlp.model.jlow] -= x[n+1:n+nlow]
+    c[nlp.model.jupp] -= x[n+nlow+1:n+nlow+nupp]
+    c[nlp.model.jrng] -= x[n+nlow+nupp+1:n+nlow+nupp+nrng]
   end
   return c
 end
 
 function jac_structure!(nlp :: SlackModels, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
-  nnzj = nlp.model.meta.nnzj
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
+  nnzj = nlp.model.nnzj
   @views jac_structure!(nlp.model, rows[1:nnzj], cols[1:nnzj])
-  jlow = nlp.model.meta.jlow
-  jupp = nlp.model.meta.jupp
-  jrng = nlp.model.meta.jrng
+  jlow = nlp.model.jlow
+  jupp = nlp.model.jupp
+  jrng = nlp.model.jrng
   nj, lj = nnzj, length(jlow)
   rows[nj+1:nj+lj] .= jlow
   nj, lj = nj + lj, length(jupp)
   rows[nj+1:nj+lj] .= jupp
   nj, lj = nj + lj, length(jrng)
   rows[nj+1:nj+lj] .= jrng
-  cols[nnzj+1:end] .= n+1:nlp.meta.nvar
+  cols[nnzj+1:end] .= n+1:nlp.nvar
   return rows, cols
 end
 
 function jac_coord!(nlp :: SlackModels, x :: AbstractVector, vals :: AbstractVector)
-  n = nlp.model.meta.nvar
-  nnzj = nlp.model.meta.nnzj
+  n = nlp.model.nvar
+  nnzj = nlp.model.nnzj
   @views jac_coord!(nlp.model, x[1:n], vals[1:nnzj])
-  vals[nnzj+1:nlp.meta.nnzj] .= -1
+  vals[nnzj+1:nlp.nnzj] .= -1
   return vals
 end
 
 function jprod!(nlp :: SlackModels, x :: AbstractVector, v :: AbstractVector, jv :: AbstractVector)
   # J(X) V = [J(x)  -I] [vₓ] = J(x) vₓ - vₛ
   #                     [vₛ]
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   @views jprod!(nlp.model, x[1:n], v[1:n], jv)
   k = 1
   # use 3 loops to avoid forming [jlow ; jupp ; jrng]
-  for j in nlp.model.meta.jlow
+  for j in nlp.model.jlow
     jv[j] -= v[n+k]
     k += 1
   end
-  for j in nlp.model.meta.jupp
+  for j in nlp.model.jupp
     jv[j] -= v[n+k]
     k += 1
   end
-  for j in nlp.model.meta.jrng
+  for j in nlp.model.jrng
     jv[j] -= v[n+k]
     k += 1
   end
@@ -244,15 +244,15 @@ end
 function jtprod!(nlp :: SlackModels, x :: AbstractVector, v :: AbstractVector, jtv :: AbstractVector)
   # J(X)ᵀ v = [J(x)ᵀ] v = [J(x)ᵀ v]
   #           [ -I  ]     [  -v   ]
-  n = nlp.model.meta.nvar
-  nlow = length(nlp.model.meta.jlow)
-  nupp = length(nlp.model.meta.jupp)
-  nrng = length(nlp.model.meta.jrng)
+  n = nlp.model.nvar
+  nlow = length(nlp.model.jlow)
+  nupp = length(nlp.model.jupp)
+  nrng = length(nlp.model.jrng)
   @views begin
     jtprod!(nlp.model, x[1:n], v, jtv[1:n])
-    jtv[n+1:n+nlow] = -v[nlp.model.meta.jlow]
-    jtv[n+nlow+1:n+nlow+nupp] = -v[nlp.model.meta.jupp]
-    jtv[n+nlow+nupp+1:nlp.meta.nvar] = -v[nlp.model.meta.jrng]
+    jtv[n+1:n+nlow] = -v[nlp.model.jlow]
+    jtv[n+nlow+1:n+nlow+nupp] = -v[nlp.model.jupp]
+    jtv[n+nlow+nupp+1:nlp.nvar] = -v[nlp.model.jrng]
   end
   return jtv
 end
@@ -263,27 +263,27 @@ end
 
 function hess_coord!(nlp :: SlackModels, x :: AbstractVector, vals :: AbstractVector;
                      obj_weight :: Float64=1.0)
-  n = nlp.model.meta.nvar
+  n = nlp.model.nvar
   return hess_coord!(nlp.model, view(x, 1:n), vals, obj_weight=obj_weight)
 end
 
 function hess_coord!(nlp :: SlackModels, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector;
                      obj_weight :: Float64=1.0)
-  n = nlp.model.meta.nvar
+  n = nlp.model.nvar
   return hess_coord!(nlp.model, view(x, 1:n), y, vals, obj_weight=obj_weight)
 end
 
 # Kept in case some model implements `hess` but not `hess_coord/structure`
 function hess(nlp :: SlackModels, x :: AbstractVector{T}; kwargs...) where T
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   Hx = hess(nlp.model, view(x, 1:n); kwargs...)
   return [Hx spzeros(T, n, ns); spzeros(T, ns, n + ns)]
 end
 
 function hess(nlp :: SlackModels, x :: AbstractVector{T}, y :: AbstractVector{T}; kwargs...) where T
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   Hx = hess(nlp.model, view(x, 1:n), y; kwargs...)
   return [Hx spzeros(T, n, ns); spzeros(T, ns, n + ns)]
 end
@@ -291,31 +291,31 @@ end
 function hprod!(nlp :: SlackModels, x :: AbstractVector, v :: AbstractVector,
     hv :: AbstractVector;
     obj_weight :: Float64=1.0)
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   # using hv[1:n] doesn't seem to work here
   @views hprod!(nlp.model, x[1:n], v[1:n], hv[1:n], obj_weight=obj_weight)
-  hv[n+1:nlp.meta.nvar] .= 0
+  hv[n+1:nlp.nvar] .= 0
   return hv
 end
 
 function hprod!(nlp :: SlackModels, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; obj_weight :: Float64=1.0)
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   # using hv[1:n] doesn't seem to work here
   @views hprod!(nlp.model, x[1:n], y, v[1:n], hv[1:n], obj_weight=obj_weight)
-  hv[n+1:nlp.meta.nvar] .= 0
+  hv[n+1:nlp.nvar] .= 0
   return hv
 end
 
 function residual!(nlp :: SlackNLSModel, x :: AbstractVector, Fx :: AbstractVector)
-  return residual!(nlp.model, view(x, 1:nlp.model.meta.nvar), Fx)
+  return residual!(nlp.model, view(x, 1:nlp.model.nvar), Fx)
 end
 
 function jac_residual(nlp :: SlackNLSModel, x :: AbstractVector{T}) where T
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
-  ne = nlp.nls_meta.nequ
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
+  ne = nlp.nls_nequ
   Jx = jac_residual(nlp.model, @view x[1:n])
   if issparse(Jx)
     return [Jx spzeros(T, ne, ns)]
@@ -329,17 +329,17 @@ function jac_structure_residual!(nls :: SlackNLSModel, rows :: AbstractVector{<:
 end
 
 function jac_coord_residual!(nls :: SlackNLSModel, x :: AbstractVector, vals :: AbstractVector)
-  return jac_coord_residual!(nls.model, view(x, 1:nls.model.meta.nvar), vals)
+  return jac_coord_residual!(nls.model, view(x, 1:nls.model.nvar), vals)
 end
 
 function jprod_residual!(nlp :: SlackNLSModel, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
-  return jprod_residual!(nlp.model, view(x, 1:nlp.model.meta.nvar),
-                         v[1:nlp.model.meta.nvar], Jv)
+  return jprod_residual!(nlp.model, view(x, 1:nlp.model.nvar),
+                         v[1:nlp.model.nvar], Jv)
 end
 
 function jtprod_residual!(nlp :: SlackNLSModel, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   @views jtprod_residual!(nlp.model, x[1:n], v, Jtv[1:n])
   Jtv[n+1:n+ns] .= 0
   return Jtv
@@ -349,13 +349,13 @@ function jac_op_residual!(nls :: SlackNLSModel, x :: AbstractVector,
                           Jv :: AbstractVector, Jtv :: AbstractVector)
   prod = @closure v -> jprod_residual!(nls, x, v, Jv)
   ctprod = @closure v -> jtprod_residual!(nls, x, v, Jtv)
-  return LinearOperator{Float64}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+  return LinearOperator{Float64}(nls.nls_nequ, nls.nvar,
                                  false, false, prod, ctprod, ctprod)
 end
 
 function hess_residual(nlp :: SlackNLSModel, x :: AbstractVector{T}, v :: AbstractVector{T}) where T
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   Hx = hess_residual(nlp.model, view(x, 1:n), v)
   if issparse(Hx)
     return [Hx spzeros(T, n, ns); spzeros(T, ns, n + ns)]
@@ -369,12 +369,12 @@ function hess_structure_residual!(nls :: SlackNLSModel, rows :: AbstractVector{<
 end
 
 function hess_coord_residual!(nls :: SlackNLSModel, x :: AbstractVector, v :: AbstractVector, vals :: AbstractVector)
-  return hess_coord_residual!(nls.model, view(x, 1:nls.model.meta.nvar), v, vals)
+  return hess_coord_residual!(nls.model, view(x, 1:nls.model.nvar), v, vals)
 end
 
 function jth_hess_residual(nlp :: SlackNLSModel, x :: AbstractVector{T}, i :: Int) where T
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   Hx = jth_hess_residual(nlp.model, view(x, 1:n), i)
   if issparse(Hx)
     return [Hx spzeros(T, n, ns); spzeros(T, ns, n + ns)]
@@ -384,8 +384,8 @@ function jth_hess_residual(nlp :: SlackNLSModel, x :: AbstractVector{T}, i :: In
 end
 
 function hprod_residual!(nlp :: SlackNLSModel, x :: AbstractVector, i :: Int, v :: AbstractVector, Hv :: AbstractVector)
-  n = nlp.model.meta.nvar
-  ns = nlp.meta.nvar - n
+  n = nlp.model.nvar
+  ns = nlp.nvar - n
   @views hprod_residual!(nlp.model, x[1:n], i, v[1:n], Hv[1:n])
   Hv[n+1:n+ns] .= 0
   return Hv
@@ -393,6 +393,6 @@ end
 
 function hess_op_residual!(nls :: SlackNLSModel, x :: AbstractVector, i :: Int, Hiv :: AbstractVector)
   prod = @closure v -> hprod_residual!(nls, x, i, v, Hiv)
-  return LinearOperator{Float64}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+  return LinearOperator{Float64}(nls.nvar, nls.nvar,
                                  true, true, prod, prod, prod)
 end

--- a/test/multiple-precision.jl
+++ b/test/multiple-precision.jl
@@ -1,15 +1,15 @@
 function multiple_precision(nlp :: AbstractNLPModel;
                             precisions :: Array = [Float16, Float32, Float64, BigFloat])
   for T in precisions
-    x = ones(T, nlp.meta.nvar)
+    x = ones(T, nlp.nvar)
     @test typeof(obj(nlp, x)) == T
     @test eltype(grad(nlp, x)) == T
     @test eltype(hess(nlp, x)) == T
-    if nlp.meta.ncon > 0
+    if nlp.ncon > 0
       @test eltype(cons(nlp, x)) == T
       @test eltype(jac(nlp, x)) == T
-      @test eltype(hess(nlp, x, ones(T, nlp.meta.ncon))) == T
-      @test eltype(hess(nlp, x, ones(T, nlp.meta.ncon), obj_weight=one(T))) == T
+      @test eltype(hess(nlp, x, ones(T, nlp.ncon))) == T
+      @test eltype(hess(nlp, x, ones(T, nlp.ncon), obj_weight=one(T))) == T
     end
   end
 end
@@ -17,13 +17,13 @@ end
 function multiple_precision(nls :: AbstractNLSModel;
                             precisions :: Array = [Float16, Float32, Float64, BigFloat])
   for T in precisions
-    x = ones(T, nls.meta.nvar)
+    x = ones(T, nls.nvar)
     @test eltype(residual(nls, x)) == T
     @test eltype(jac_residual(nls, x)) == T
-    @test eltype(hess_residual(nls, x, ones(T, nls.nls_meta.nequ))) == T
+    @test eltype(hess_residual(nls, x, ones(T, nls.nls_nequ))) == T
     @test typeof(obj(nls, x)) == T
     @test eltype(grad(nls, x)) == T
-    if nls.meta.ncon > 0
+    if nls.ncon > 0
       @test eltype(cons(nls, x)) == T
       @test eltype(jac(nls, x)) == T
     end

--- a/test/nls_consistency.jl
+++ b/test/nls_consistency.jl
@@ -17,8 +17,8 @@ end
 
 function consistent_nls_functions(nlss; rtol=1.0e-8, exclude=[])
   N = length(nlss)
-  n = nls_meta(nlss[1]).nvar
-  m = nls_meta(nlss[1]).nequ
+  n = nlss[1].nvar
+  m = nlss[1].nls_nequ
 
   tmp_n = zeros(n)
   tmp_m = zeros(m)
@@ -46,12 +46,12 @@ function consistent_nls_functions(nlss; rtol=1.0e-8, exclude=[])
       end
       V = jac_coord_residual(nlss[i], x)
       I, J = jac_structure_residual(nlss[i])
-      @test length(I) == length(J) == length(V) == nlss[i].nls_meta.nnzj
+      @test length(I) == length(J) == length(V) == nlss[i].nls_nnzj
       I2, J2 = copy(I), copy(J)
       jac_structure_residual!(nlss[i], I2, J2)
       @test I == I2
       @test J == J2
-      tmp_V = zeros(nlss[i].nls_meta.nnzj)
+      tmp_V = zeros(nlss[i].nls_nnzj)
       jac_coord_residual!(nlss[i], x, tmp_V)
       @test tmp_V == V
     end
@@ -107,13 +107,13 @@ function consistent_nls_functions(nlss; rtol=1.0e-8, exclude=[])
       if !(hess_coord_residual in exclude)
         V = hess_coord_residual(nlss[i], x, w)
         I, J = hess_structure_residual(nlss[i])
-        @test length(I) == length(J) == length(V) == nlss[i].nls_meta.nnzh
+        @test length(I) == length(J) == length(V) == nlss[i].nls_nnzh
         @test sparse(I, J, V, n, n) == Hs[i]
         I2, J2 = copy(I), copy(J)
         hess_structure_residual!(nlss[i], I2, J2)
         @test I == I2
         @test J == J2
-        tmp_V = zeros(nlss[i].nls_meta.nnzh)
+        tmp_V = zeros(nlss[i].nls_nnzh)
         hess_coord_residual!(nlss[i], x, w, tmp_V)
         @test tmp_V == V
       end

--- a/test/problems/brownden.jl
+++ b/test/problems/brownden.jl
@@ -65,7 +65,7 @@ function NLPModels.hess(nlp :: BROWNDEN, x :: AbstractVector{T}; obj_weight=1.0)
 end
 
 function NLPModels.hess_structure!(nlp :: BROWNDEN, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
-  n = nlp.meta.nvar
+  n = nlp.nvar
   I = ((i,j) for i = 1:n, j = 1:n if i ≥ j)
   rows .= getindex.(I, 1)
   cols .= getindex.(I, 2)

--- a/test/problems/hs10.jl
+++ b/test/problems/hs10.jl
@@ -71,7 +71,7 @@ end
 
 function NLPModels.hprod!(nlp :: HS10, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
   increment!(nlp, :neval_hprod)
-  Hv[1:nlp.meta.nvar] .= y[1] * [-6 * v[1] + 2 * v[2]; 2 * v[1] - 2 * v[2]]
+  Hv[1:nlp.nvar] .= y[1] * [-6 * v[1] + 2 * v[2]; 2 * v[1] - 2 * v[2]]
   return Hv
 end
 

--- a/test/problems/hs5.jl
+++ b/test/problems/hs5.jl
@@ -39,7 +39,7 @@ function NLPModels.hess(nlp :: HS5, x :: AbstractVector{T}; obj_weight=one(T)) w
 end
 
 function NLPModels.hess_structure!(nlp :: HS5, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
-  I = ((i,j) for i = 1:nlp.meta.nvar, j = 1:nlp.meta.nvar if i ≥ j)
+  I = ((i,j) for i = 1:nlp.nvar, j = 1:nlp.nvar if i ≥ j)
   rows .= getindex.(I, 1)
   cols .= getindex.(I, 2)
   return rows, cols

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,20 +50,20 @@ end
 
 # ADNLPModel with no functions
 model = ADNLPModel(x->dot(x,x), zeros(2), name="square")
-@assert model.meta.name == "square"
+@assert model.name == "square"
 
 model = genrose_autodiff()
 for counter in fieldnames(typeof(model.counters))
   @eval @assert $counter(model) == 0
 end
 
-obj(model, model.meta.x0)
+obj(model, model.x0)
 @assert neval_obj(model) == 1
 
 reset!(model)
 @assert neval_obj(model) == 0
 
-@test_throws(NotImplementedError, jth_con(model, model.meta.x0, 1))
+@test_throws(NotImplementedError, jth_con(model, model.x0, 1))
 
 include("test_tools.jl")
 

--- a/test/test_feasibility_nls_model.jl
+++ b/test/test_feasibility_nls_model.jl
@@ -11,10 +11,10 @@ function feasibility_nls_test()
                      lcon=-ones(2), ucon=2*ones(2))
     nls = FeasibilityResidual(nlp)
 
-    @test nls.meta.nvar == 4
-    @test nls.nls_meta.nequ == 2
-    @test nls.meta.lvar == [-0.3; -0.5; -1.0; -1.0]
-    @test nls.meta.uvar == [ 1.2;  3.4;  2.0;  2.0]
+    @test nls.nvar == 4
+    @test nls.nls_nequ == 2
+    @test nls.lvar == [-0.3; -0.5; -1.0; -1.0]
+    @test nls.uvar == [ 1.2;  3.4;  2.0;  2.0]
     @test isapprox(residual(nls, [1.0; 1.0; 0.0; 0.0]), zeros(2), rtol=1e-8)
     @test isapprox(residual(nls, [0.0; 1.0; 2.0; 3.0]), [-3.0; -2.0], rtol=1e-8)
   end

--- a/test/test_lls_model.jl
+++ b/test/test_lls_model.jl
@@ -25,8 +25,8 @@ function lls_test()
       V = jac_coord(nls, x)
       @test sparse(I, J, V, ncon, nvar) == C
 
-      @test nls.meta.nlin == length(nls.meta.lin) == ncon
-      @test nls.meta.nnln == length(nls.meta.nln) == 0
+      @test nls.nlin == length(nls.lin) == ncon
+      @test nls.nnln == length(nls.nln) == 0
     end
   end
 end

--- a/test/test_memory_of_coord.jl
+++ b/test/test_memory_of_coord.jl
@@ -1,6 +1,6 @@
 function test_memory_of_coord_of_nlp(nlp :: AbstractNLPModel)
-  n = nlp.meta.nvar
-  m = nlp.meta.ncon
+  n = nlp.nvar
+  m = nlp.ncon
 
   x = 10 * [-(-1.0)^i for i = 1:n]
   y = [-(-1.0)^i for i = 1:m]
@@ -8,7 +8,7 @@ function test_memory_of_coord_of_nlp(nlp :: AbstractNLPModel)
   # Hessian unconstrained test
   vals = hess_coord(nlp, x)
   al1 = @allocated hess_coord(nlp, x)
-  V = zeros(nlp.meta.nnzh)
+  V = zeros(nlp.nnzh)
   hess_coord!(nlp, x, V)
   al2 = @allocated hess_coord!(nlp, x, V)
   @test al2 < al1 - 50
@@ -22,7 +22,7 @@ function test_memory_of_coord_of_nlp(nlp :: AbstractNLPModel)
 
     vals = jac_coord(nlp, x)
     al1 = @allocated vals = jac_coord(nlp, x)
-    V = zeros(nlp.meta.nnzj)
+    V = zeros(nlp.nnzj)
     jac_coord!(nlp, x, vals)
     al2 = @allocated jac_coord!(nlp, x, vals)
     @test al2 < al1 - 50

--- a/test/test_qn_model.jl
+++ b/test/test_qn_model.jl
@@ -4,10 +4,10 @@ function check_qn_model(qnmodel)
   rtol  = 1e-8
   model = qnmodel.model
   @assert typeof(qnmodel) <: NLPModels.QuasiNewtonModel
-  @assert qnmodel.meta.nvar == model.meta.nvar
-  @assert qnmodel.meta.ncon == model.meta.ncon
+  @assert qnmodel.nvar == model.nvar
+  @assert qnmodel.ncon == model.ncon
 
-  x = [-(-1.0)^i for i = 1:qnmodel.meta.nvar]
+  x = [-(-1.0)^i for i = 1:qnmodel.nvar]
 
   @assert isapprox(obj(model, x), obj(qnmodel, x), rtol=rtol)
   @assert neval_obj(model) == 2
@@ -21,8 +21,8 @@ function check_qn_model(qnmodel)
   @assert isapprox(jac(model, x), jac(qnmodel, x), rtol=rtol)
   @assert neval_jac(model) == 2
 
-  v = [-(-1.0)^i for i = 1:qnmodel.meta.nvar]
-  u = [-(-1.0)^i for i = 1:qnmodel.meta.ncon]
+  v = [-(-1.0)^i for i = 1:qnmodel.nvar]
+  u = [-(-1.0)^i for i = 1:qnmodel.ncon]
 
   @assert isapprox(jprod(model, x, v), jprod(qnmodel, x, v), rtol=rtol)
   @assert neval_jprod(model) == 2
@@ -32,7 +32,7 @@ function check_qn_model(qnmodel)
 
   H = hess_op(qnmodel, x)
   @assert typeof(H) <: LinearOperators.AbstractLinearOperator
-  @assert size(H) == (model.meta.nvar, model.meta.nvar)
+  @assert size(H) == (model.nvar, model.nvar)
   @assert isapprox(H * v, hprod(qnmodel, x, v), rtol=rtol)
 
   g = grad(qnmodel, x)

--- a/test/test_slack_model.jl
+++ b/test/test_slack_model.jl
@@ -26,19 +26,19 @@
     rtol  = 1e-8
     model = smodel.model
     @test typeof(smodel) == NLPModels.SlackModel
-    n = model.meta.nvar   # number of variables in original model
-    N = smodel.meta.nvar  # number of variables in slack model
-    jlow = model.meta.jlow; nlow = length(jlow)
-    jupp = model.meta.jupp; nupp = length(jupp)
-    jrng = model.meta.jrng; nrng = length(jrng)
-    jfix = model.meta.jfix; nfix = length(jfix)
+    n = model.nvar   # number of variables in original model
+    N = smodel.nvar  # number of variables in slack model
+    jlow = model.jlow; nlow = length(jlow)
+    jupp = model.jupp; nupp = length(jupp)
+    jrng = model.jrng; nrng = length(jrng)
+    jfix = model.jfix; nfix = length(jfix)
 
-    @test N == n + model.meta.ncon - nfix
-    @test smodel.meta.ncon == model.meta.ncon
+    @test N == n + model.ncon - nfix
+    @test smodel.ncon == model.ncon
 
     x = [-(-1.0)^i for i = 1:N]
     s = x[n+1:N]
-    y = [-(-1.0)^i for i = 1:smodel.meta.ncon]
+    y = [-(-1.0)^i for i = 1:smodel.ncon]
 
     # slack variables do not influence objective value
     @test isapprox(obj(model, x[1:n]), obj(smodel, x), rtol=rtol)
@@ -91,10 +91,10 @@
     v = [-(-1.0)^i for i = 1:N]
     Jv = J * v
     @test all(jprod(smodel, x, v) ≈ Jv)
-    jv = zeros(smodel.meta.ncon)
+    jv = zeros(smodel.ncon)
     @test all(jprod!(smodel, x, v, jv) ≈ Jv)
 
-    u = [-(-1.0)^i for i = 1:smodel.meta.ncon]
+    u = [-(-1.0)^i for i = 1:smodel.ncon]
     Jtu = J' * u
     @test all(jtprod(smodel, x, u) ≈ Jtu)
     jtu = zeros(N)
@@ -116,5 +116,5 @@ end
 @testset "Test that type is maintained (#217)" begin
   nlp = ADNLPModel(x -> dot(x, x), ones(Float16, 2), c=x->sum(x), lcon=[-1.0], ucon=[1.0])
   snlp = SlackModel(nlp)
-  @test eltype(snlp.meta.x0) == Float16
+  @test eltype(snlp.x0) == Float16
 end

--- a/test/test_view_subarray.jl
+++ b/test/test_view_subarray.jl
@@ -1,6 +1,6 @@
 function test_view_subarray_nlp(nlp)
   @testset "Test view subarray of NLPs" begin
-    n, m = nlp.meta.nvar, nlp.meta.ncon
+    n, m = nlp.nvar, nlp.ncon
     N = 2n
     Vidxs = [1:2:N, collect(N:-2:1)]
     Cidxs = if m > 0
@@ -114,7 +114,7 @@ end
 
 function test_view_subarray_nls(nls)
   @testset "Test view subarray of NLSs" begin
-    n, ne = nls.meta.nvar, nls.nls_meta.nequ
+    n, ne = nls.nvar, nls.nls_nequ
     N = 2n
     Vidxs = [1:n, n.+(1:n), 1:2:N, collect(N:-2:1)]
     N = 2ne


### PR DESCRIPTION
Tackles #92 by defining getproperty so that `nlp.X = nlp.meta.X`, i.e., we can call `nlp.meta` directly.
For NLS models we define `nls.nls_X = nls.nls_meta.X` as well.
An alternative would be defining something like `get_X(nlp) = nlp.meta.X`, but `nlp.nvar` seems more natural.

Closes #92