### PR TITLE
Create prod functions that accept structure

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,10 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
-#NLPModelsJuMP = "792afdf1-32c1-5681-94e0-d7bf7a5df49e"
 OptimizationProblems = "5049e819-d29b-5fba-b941-0eee7e64c1c6"
 
 [compat]
 Documenter = "~0.24"
-JuMP = "≥ 0.18.6"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -136,5 +136,8 @@ hessian_check_from_grad
 ## Internal
 
 ```@docs
+coo_prod!
+coo_sym_prod!
 NLPModels.increment!
+NLPModels.decrement!
 ```

--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -68,6 +68,15 @@ function increment!(nlp :: AbstractNLPModel, s :: Symbol)
 end
 
 """
+    decrement!(nlp, s)
+
+Decrement counter `s` of problem `nlp`.
+"""
+function decrement!(nlp :: AbstractNLPModel, s :: Symbol)
+  setfield!(nlp.counters, s, getfield(nlp.counters, s) - 1)
+end
+
+"""
     sum_counters(counters)
 
 Sum all counters of `counters`.
@@ -273,6 +282,25 @@ jprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector)
   throw(NotImplementedError("jprod!"))
 
 """
+    Jv = jprod!(nlp, rows, cols, vals, v, Jv)
+
+Evaluate ``∇c(x)v``, the Jacobian-vector product, where the Jacobian is given by
+`(rows, cols, vals)` in triplet format.
+"""
+function jprod!(nlp::AbstractNLPModel, rows::AbstractVector{<: Integer}, cols::AbstractVector{<: Integer}, vals::AbstractVector, v::AbstractVector, Jv::AbstractVector)
+  increment!(nlp, :neval_jprod)
+  coo_prod!(rows, cols, vals, v, Jv)
+end
+
+"""
+    Jv = jprod!(nlp, x, rows, cols, v, Jv)
+
+Evaluate ``∇c(x)v``, the Jacobian-vector product at `x` in place.
+`(rows, cols)` should be the Jacobian structure in triplet format.
+"""
+jprod!(nlp::AbstractNLPModel, x::AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, v::AbstractVector, Jv::AbstractVector) = jprod!(nlp, x, v, Jv)
+
+"""
     Jtv = jtprod(nlp, x, v, Jtv)
 
 Evaluate ``∇c(x)^Tv``, the transposed-Jacobian-vector product at `x`.
@@ -289,6 +317,25 @@ Evaluate ``∇c(x)^Tv``, the transposed-Jacobian-vector product at `x` in place.
 """
 jtprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector) =
   throw(NotImplementedError("jtprod!"))
+
+"""
+    Jtv = jtprod!(nlp, rows, cols, vals, v, Jtv)
+
+Evaluate ``∇c(x)^Tv``, the transposed-Jacobian-vector product, where the
+Jacobian is given by `(rows, cols, vals)` in triplet format.
+"""
+function jtprod!(nlp::AbstractNLPModel, rows::AbstractVector{<: Integer}, cols::AbstractVector{<: Integer}, vals::AbstractVector, v::AbstractVector, Jtv::AbstractVector)
+  increment!(nlp, :neval_jtprod)
+  coo_prod!(cols, rows, vals, v, Jtv)
+end
+
+"""
+    Jtv = jtprod!(nlp, x, rows, cols, v, Jtv)
+
+Evaluate ``∇c(x)^Tv``, the transposed-Jacobian-vector product at `x` in place.
+`(rows, cols)` should be the Jacobian structure in triplet format.
+"""
+jtprod!(nlp::AbstractNLPModel, x::AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, v::AbstractVector, Jtv::AbstractVector) = jtprod!(nlp, x, v, Jtv)
 
 """
     J = jac_op(nlp, x)
@@ -318,6 +365,34 @@ function jac_op!(nlp :: AbstractNLPModel, x :: AbstractVector,
   ctprod = @closure v -> jtprod!(nlp, x, v, Jtv)
   return LinearOperator{Float64}(nlp.meta.ncon, nlp.meta.nvar,
                                  false, false, prod, ctprod, ctprod)
+end
+
+"""
+    J = jac_op!(nlp, rows, cols, vals, Jv, Jtv)
+
+Return the Jacobian given by `(rows, cols, vals)` as a linear operator.
+The resulting object may be used as if it were a matrix, e.g., `J * v` or `J' * v`.
+The values `Jv` and `Jtv` are used as preallocated storage for the operations.
+"""
+function jac_op!(nlp :: AbstractNLPModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, vals :: AbstractVector, Jv :: AbstractVector, Jtv :: AbstractVector)
+  prod = @closure v -> jprod!(nlp, rows, cols, vals, v, Jv)
+  ctprod = @closure v -> jtprod!(nlp, rows, cols, vals, v, Jtv)
+  return LinearOperator{Float64}(nlp.meta.ncon, nlp.meta.nvar,
+                                 false, false, prod, ctprod, ctprod)
+end
+
+"""
+    J = jac_op!(nlp, x, rows, cols, Jv, Jtv)
+
+Return the Jacobian at `x` as a linear operator.
+The resulting object may be used as if it were a matrix, e.g., `J * v` or
+`J' * v`. `(rows, cols)` should be the sparsity structure of the Jacobian.
+The values `Jv` and `Jtv` are used as preallocated storage for the operations.
+"""
+function jac_op!(nlp :: AbstractNLPModel, x :: AbstractVector, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, Jv :: AbstractVector, Jtv :: AbstractVector)
+  vals = jac_coord(nlp, x)
+  decrement!(nlp, :neval_jac)
+  return jac_op!(nlp, rows, cols, vals, Jv, Jtv)
 end
 
 function jth_hprod(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector, j::Integer)
@@ -470,6 +545,27 @@ function hprod!(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector, Hv:
 end
 
 """
+    Hv = hprod!(nlp, rows, cols, vals, v, Hv)
+
+Evaluate the product of the objective or Lagrangian Hessian given by `(rows, cols, vals)` in
+triplet format with the vector `v` in place. Only one triangle of the Hessian should be given.
+"""
+function hprod!(nlp::AbstractNLPModel, rows::AbstractVector{<: Integer}, cols::AbstractVector{<: Integer}, vals::AbstractVector, v::AbstractVector, Hv::AbstractVector)
+  increment!(nlp, :neval_hprod)
+  coo_sym_prod!(cols, rows, vals, v, Hv)
+end
+
+"""
+    Hv = hprod!(nlp, x, rows, cols, v, Hv)
+
+Evaluate the product of the objective Hessian at `x` with the vector `v` in
+place, where the objective Hessian is
+$(OBJECTIVE_HESSIAN).
+`(rows, cols)` should be the Hessian structure in triplet format.
+"""
+hprod!(nlp::AbstractNLPModel, x::AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, v::AbstractVector, Hv::AbstractVector; obj_weight::Real=1.0) = hprod!(nlp, x, v, Hv, obj_weight=obj_weight)
+
+"""
     Hv = hprod!(nlp, x, y, v, Hv; obj_weight=1.0)
 
 Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
@@ -478,6 +574,16 @@ $(LAGRANGIAN_HESSIAN).
 """
 hprod!(nlp::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector, ::AbstractVector; obj_weight :: Float64=1.0) =
   throw(NotImplementedError("hprod!"))
+
+"""
+    Hv = hprod!(nlp, x, y, rows, cols, v, Hv)
+
+Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
+place, where the Lagrangian Hessian is
+$(LAGRANGIAN_HESSIAN).
+`(rows, cols)` should be the Hessian structure in triplet format.
+"""
+hprod!(nlp::AbstractNLPModel, x::AbstractVector, y::AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, v::AbstractVector, Hv::AbstractVector; obj_weight::Real=1.0) = hprod!(nlp, x, y, v, Hv, obj_weight=obj_weight)
 
 """
     H = hess_op(nlp, x; obj_weight=1.0)
@@ -524,6 +630,38 @@ function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, Hv :: AbstractVe
 end
 
 """
+    H = hess_op!(nlp, rows, cols, vals, Hv)
+
+Return the Hessian given by `(rows, cols, vals)` as a linear operator,
+and storing the result on `Hv`. The resulting
+object may be used as if it were a matrix, e.g., `w = H * v`.
+  The vector `Hv` is used as preallocated storage for the operation.  The linear operator H
+represents
+$(OBJECTIVE_HESSIAN).
+"""
+function hess_op!(nlp :: AbstractNLPModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, vals :: AbstractVector, Hv :: AbstractVector)
+  prod = @closure v -> hprod!(nlp, rows, cols, vals, v, Hv)
+  return LinearOperator{Float64}(nlp.meta.nvar, nlp.meta.nvar,
+                                 true, true, prod, prod, prod)
+end
+
+"""
+    H = hess_op!(nlp, x, rows, cols, Hv; obj_weight=1.0)
+
+Return the objective Hessian at `x` with objective function scaled by
+`obj_weight` as a linear operator, and storing the result on `Hv`. The resulting
+object may be used as if it were a matrix, e.g., `w = H * v`.
+`(rows, cols)` should be the sparsity structure of the Hessian.
+The vector `Hv` is used as preallocated storage for the operation.  The linear operator H
+represents
+$(OBJECTIVE_HESSIAN).
+"""
+function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, Hv :: AbstractVector; obj_weight::Real=one(eltype(x)))
+  vals = hess_coord(nlp, x, obj_weight=obj_weight)
+  return hess_op!(nlp, rows, cols, vals, Hv)
+end
+
+"""
     H = hess_op!(nlp, x, y, Hv; obj_weight=1.0)
 
 Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
@@ -538,6 +676,24 @@ function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, y :: AbstractVec
   return LinearOperator{Float64}(nlp.meta.nvar, nlp.meta.nvar,
                                  true, true, prod, prod, prod)
 end
+
+"""
+    H = hess_op!(nlp, x, y, rows, cols, Hv; obj_weight=1.0)
+
+Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
+`obj_weight` as a linear operator, and storing the result on `Hv`. The resulting
+object may be used as if it were a matrix, e.g., `w = H * v`.
+`(rows, cols)` should be the sparsity structure of the Hessian.
+The vector `Hv` is used as preallocated storage for the operation.  The linear operator H
+represents
+$(OBJECTIVE_HESSIAN).
+"""
+function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, y :: AbstractVector, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, Hv :: AbstractVector; obj_weight::Real=one(eltype(x)))
+  vals = hess_coord(nlp, x, y, obj_weight=obj_weight)
+  decrement!(nlp, :neval_hess)
+  return hess_op!(nlp, rows, cols, vals, Hv)
+end
+
 
 push!(nlp :: AbstractNLPModel, args...; kwargs...) =
   throw(NotImplementedError("push!"))

--- a/src/nlp_utils.jl
+++ b/src/nlp_utils.jl
@@ -1,3 +1,5 @@
+export coo_prod!, coo_sym_prod!
+
 # Check that arrays have a prescribed size.
 # https://groups.google.com/forum/?fromgroups=#!topic/julia-users/b6RbQ2amKzg
 macro lencheck(l, vars...)
@@ -22,4 +24,40 @@ macro rangecheck(lo, hi, vars...)
             end))
   end
   Expr(:block, exprs...)
+end
+
+"""
+    coo_prod!(rows, cols, vals, v, Av)
+
+Compute the product of a matrix `A` given by `(rows, cols, vals)` and the vector `v`.
+The result is stored in `Av`, which should have length equals to the number of rows of `A`.
+"""
+function coo_prod!(rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, vals :: AbstractVector, v :: AbstractVector, Av :: AbstractVector)
+  fill!(Av, zero(eltype(v)))
+  nnz = length(rows)
+  @inbounds for k = 1:nnz
+    i, j = rows[k], cols[k]
+    Av[i] += vals[k] * v[j]
+  end
+  return Av
+end
+
+"""
+    coo_sym_prod!(rows, cols, vals, v, Av)
+
+Compute the product of a symmetric matrix `A` given by `(rows, cols, vals)` and the vector `v`.
+The result is stored in `Av`, which should have length equals to the number of rows of `A`.
+Only one triangle of `A` should be passed.
+"""
+function coo_sym_prod!(rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, vals :: AbstractVector, v :: AbstractVector, Av :: AbstractVector)
+  fill!(Av, zero(eltype(v)))
+  nnz = length(rows)
+  @inbounds for k = 1:nnz
+    i, j, a = rows[k], cols[k], vals[k]
+    Av[i] += a * v[j]
+    if i != j
+      Av[j] += a * v[i]
+    end
+  end
+  return Av
 end

--- a/src/qn_model.jl
+++ b/src/qn_model.jl
@@ -40,6 +40,10 @@ function increment!(nlp :: QuasiNewtonModel, s :: Symbol)
   increment!(nlp.model, s)
 end
 
+function decrement!(nlp :: QuasiNewtonModel, s :: Symbol)
+  decrement!(nlp.model, s)
+end
+
 function reset!(nlp :: QuasiNewtonModel)
   reset!(nlp.model.counters)
   reset!(nlp.op)

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -150,6 +150,10 @@ function increment!(nlp :: SlackModels, s :: Symbol)
   increment!(nlp.model, s)
 end
 
+function decrement!(nlp :: SlackModels, s :: Symbol)
+  decrement!(nlp.model, s)
+end
+
 function reset!(nlp :: SlackModels)
   reset!(nlp.model.counters)
   return nlp

--- a/test/nls_consistency.jl
+++ b/test/nls_consistency.jl
@@ -75,6 +75,17 @@ function consistent_nls_functions(nlss; rtol=1.0e-8, exclude=[])
       @test isapprox(Jps[i], tmp_m, rtol=rtol)
       @test isapprox(Jps[i], J_ops[i] * v, rtol=rtol)
       @test isapprox(Jps[i], J_ops_inplace[i] * v, rtol=rtol)
+
+      rows, cols = jac_structure_residual(nlss[i])
+      vals = jac_coord_residual(nlss[i], x)
+      jprod_residual!(nlss[i], rows, cols, vals, v, tmp_m)
+      @test isapprox(Jps[i], tmp_m, rtol=rtol)
+      jprod_residual!(nlss[i], x, rows, cols, v, tmp_m)
+      @test isapprox(Jps[i], tmp_m, rtol=rtol)
+
+      J = jac_op_residual!(nlss[i], x, rows, cols, tmp_m, tmp_n)
+      res = J * v
+      @test isapprox(Jps[i], res, rtol=rtol)
     end
 
     v = [-(-1.0)^i for i = 1:m]
@@ -90,6 +101,17 @@ function consistent_nls_functions(nlss; rtol=1.0e-8, exclude=[])
       @test isapprox(Jtps[i], tmp_n, rtol=rtol)
       @test isapprox(Jtps[i], J_ops[i]' * v, rtol=rtol)
       @test isapprox(Jtps[i], J_ops_inplace[i]' * v, rtol=rtol)
+
+      rows, cols = jac_structure_residual(nlss[i])
+      vals = jac_coord_residual(nlss[i], x)
+      jtprod_residual!(nlss[i], rows, cols, vals, v, tmp_n)
+      @test isapprox(Jtps[i], tmp_n, rtol=rtol)
+      jtprod_residual!(nlss[i], x, rows, cols, v, tmp_n)
+      @test isapprox(Jtps[i], tmp_n, rtol=rtol)
+
+      J = jac_op_residual!(nlss[i], x, rows, cols, tmp_m, tmp_n)
+      res = J' * v
+      @test isapprox(Jtps[i], res, rtol=rtol)
     end
   end
 


### PR DESCRIPTION
cf @dpo, @amontoison 

Create/modify:
1. `jprod!(nlp, rows, cols, vals, v, Jv)` and `jtprod!` - well defined
2. `jprod!(nlp, x, rows, cols, v, Jv)` and `jtprod!` - defaults to `jprod!(nlp, x, v, Jv)`
3. `hprod!(nlp, rows, cols, vals, v, Hv)` (this works for both unc and con) - well defined
4. `hprod!(nlp, x, rows, cols, v, Hv)` - defaults to `hprod!(nlp, x, v, Hv)`
5. `hprod!(nlp, x, y, rows, cols, v, Hv)` - defaults to `hprod!(nlp, x, y, v, Hv)`
6. `jac_op!(nlp, rows, cols, vals, Jv, Jtv)` - uses 1
7. `jac_op!(nlp, x, rows, cols, Jv, Jtv)` - call `vals = jac_coord` and uses 6
8. `jac_op!(nlp, x, Jv, Jtv)` - modified to call `rows, cols = jac_structure` and `vals = jac_coord` and uses 6
9. `hess_op!` has same cases as 6, 7, 8
10. `decrement!` is implemented for use in 7.
