### PR TITLE
More multiple precision fixes

### DIFF
--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -377,7 +377,7 @@ The values `Jv` and `Jtv` are used as preallocated storage for the operations.
 function jac_op!(nlp :: AbstractNLPModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, vals :: AbstractVector, Jv :: AbstractVector, Jtv :: AbstractVector)
   prod = @closure v -> jprod!(nlp, rows, cols, vals, v, Jv)
   ctprod = @closure v -> jtprod!(nlp, rows, cols, vals, v, Jtv)
-  return LinearOperator{Float64}(nlp.meta.ncon, nlp.meta.nvar,
+  return LinearOperator{eltype(vals)}(nlp.meta.ncon, nlp.meta.nvar,
                                  false, false, prod, ctprod, ctprod)
 end
 
@@ -437,7 +437,7 @@ with objective function scaled by `obj_weight`, i.e.,
 $(OBJECTIVE_HESSIAN), rewriting `vals`.
 Only the lower triangle is returned.
 """
-function hess_coord!(nlp :: AbstractNLPModel, x :: AbstractVector, vals :: AbstractVector; obj_weight :: Real=1.0)
+function hess_coord!(nlp :: AbstractNLPModel, x :: AbstractVector, vals :: AbstractVector; obj_weight :: Real=one(eltype(x)))
   hess_coord!(nlp, x, zeros(nlp.meta.ncon), vals, obj_weight=obj_weight)
 end
 
@@ -449,7 +449,7 @@ with objective function scaled by `obj_weight`, i.e.,
 $(LAGRANGIAN_HESSIAN), rewriting `vals`.
 Only the lower triangle is returned.
 """
-hess_coord!(nlp:: AbstractNLPModel, :: AbstractVector, :: AbstractVector, ::AbstractVector; obj_weight :: Real=1.0) = throw(NotImplementedError("hess_coord!"))
+hess_coord!(nlp:: AbstractNLPModel, :: AbstractVector, :: AbstractVector, ::AbstractVector; obj_weight :: Real=one(eltype(x))) = throw(NotImplementedError("hess_coord!"))
 
 """
     vals = hess_coord(nlp, x; obj_weight=1.0)
@@ -540,7 +540,7 @@ Evaluate the product of the objective Hessian at `x` with the vector `v` in
 place, with objective function scaled by `obj_weight`, where the objective Hessian is
 $(OBJECTIVE_HESSIAN).
 """
-function hprod!(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector, Hv::AbstractVector; obj_weight :: Real=1.0)
+function hprod!(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector, Hv::AbstractVector; obj_weight :: Real=one(eltype(x)))
   hprod!(nlp, x, zeros(nlp.meta.ncon), v, Hv, obj_weight=obj_weight)
 end
 
@@ -572,7 +572,7 @@ Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
 place, with objective function scaled by `obj_weight`, where the Lagrangian Hessian is
 $(LAGRANGIAN_HESSIAN).
 """
-hprod!(nlp::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector, ::AbstractVector; obj_weight :: Real=1.0) =
+hprod!(nlp::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector, ::AbstractVector; obj_weight :: Real=one(eltype(x))) =
   throw(NotImplementedError("hprod!"))
 
 """
@@ -583,7 +583,7 @@ place, where the Lagrangian Hessian is
 $(LAGRANGIAN_HESSIAN).
 `(rows, cols)` should be the Hessian structure in triplet format.
 """
-hprod!(nlp::AbstractNLPModel, x::AbstractVector, y::AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, v::AbstractVector, Hv::AbstractVector; obj_weight::Real=1.0) = hprod!(nlp, x, y, v, Hv, obj_weight=obj_weight)
+hprod!(nlp::AbstractNLPModel, x::AbstractVector, y::AbstractVector, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}, v::AbstractVector, Hv::AbstractVector; obj_weight::Real=one(eltype(x))) = hprod!(nlp, x, y, v, Hv, obj_weight=obj_weight)
 
 """
     H = hess_op(nlp, x; obj_weight=1.0)
@@ -641,7 +641,7 @@ $(OBJECTIVE_HESSIAN).
 """
 function hess_op!(nlp :: AbstractNLPModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, vals :: AbstractVector, Hv :: AbstractVector)
   prod = @closure v -> hprod!(nlp, rows, cols, vals, v, Hv)
-  return LinearOperator{Float64}(nlp.meta.nvar, nlp.meta.nvar,
+  return LinearOperator{eltype(vals)}(nlp.meta.nvar, nlp.meta.nvar,
                                  true, true, prod, prod, prod)
 end
 

--- a/src/NLSModels.jl
+++ b/src/NLSModels.jl
@@ -279,7 +279,7 @@ vectors `Jv` and `Jtv` are used as preallocated storage for the operations.
 function jac_op_residual!(nls :: AbstractNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer}, vals :: AbstractVector, Jv :: AbstractVector, Jtv :: AbstractVector)
   prod = @closure v -> jprod_residual!(nls, rows, cols, vals, v, Jv)
   ctprod = @closure v -> jtprod_residual!(nls, rows, cols, vals, v, Jtv)
-  return LinearOperator{Float64}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+  return LinearOperator{eltype(vals)}(nls_meta(nls).nequ, nls_meta(nls).nvar,
                                  false, false, prod, ctprod, ctprod)
 end
 

--- a/src/slack_model.jl
+++ b/src/slack_model.jl
@@ -173,7 +173,7 @@ function grad!(nlp :: SlackModels, x :: AbstractVector, g :: AbstractVector)
   return g
 end
 
-function objgrad!(nlp :: SlackModels, x :: Array{Float64}, g :: Array{Float64})
+function objgrad!(nlp :: SlackModels, x :: AbstractVector, g :: AbstractVector)
   n = nlp.model.meta.nvar
   ns = nlp.meta.nvar - n
   @views f, _ = objgrad!(nlp.model, x[1:n], g[1:n])
@@ -266,13 +266,13 @@ function hess_structure!(nlp :: SlackModels, rows :: AbstractVector{<: Integer},
 end
 
 function hess_coord!(nlp :: SlackModels, x :: AbstractVector, vals :: AbstractVector;
-                     obj_weight :: Float64=1.0)
+                     obj_weight :: Real=one(eltype(x)))
   n = nlp.model.meta.nvar
   return hess_coord!(nlp.model, view(x, 1:n), vals, obj_weight=obj_weight)
 end
 
 function hess_coord!(nlp :: SlackModels, x :: AbstractVector, y :: AbstractVector, vals :: AbstractVector;
-                     obj_weight :: Float64=1.0)
+                     obj_weight :: Real=one(eltype(x)))
   n = nlp.model.meta.nvar
   return hess_coord!(nlp.model, view(x, 1:n), y, vals, obj_weight=obj_weight)
 end
@@ -294,7 +294,7 @@ end
 
 function hprod!(nlp :: SlackModels, x :: AbstractVector, v :: AbstractVector,
     hv :: AbstractVector;
-    obj_weight :: Float64=1.0)
+    obj_weight :: Real=one(eltype(x)))
   n = nlp.model.meta.nvar
   ns = nlp.meta.nvar - n
   # using hv[1:n] doesn't seem to work here
@@ -303,7 +303,7 @@ function hprod!(nlp :: SlackModels, x :: AbstractVector, v :: AbstractVector,
   return hv
 end
 
-function hprod!(nlp :: SlackModels, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; obj_weight :: Float64=1.0)
+function hprod!(nlp :: SlackModels, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, hv :: AbstractVector; obj_weight :: Real=one(eltype(x)))
   n = nlp.model.meta.nvar
   ns = nlp.meta.nvar - n
   # using hv[1:n] doesn't seem to work here
@@ -353,7 +353,7 @@ function jac_op_residual!(nls :: SlackNLSModel, x :: AbstractVector,
                           Jv :: AbstractVector, Jtv :: AbstractVector)
   prod = @closure v -> jprod_residual!(nls, x, v, Jv)
   ctprod = @closure v -> jtprod_residual!(nls, x, v, Jtv)
-  return LinearOperator{Float64}(nls_meta(nls).nequ, nls_meta(nls).nvar,
+  return LinearOperator{eltype(x)}(nls_meta(nls).nequ, nls_meta(nls).nvar,
                                  false, false, prod, ctprod, ctprod)
 end
 
@@ -397,6 +397,6 @@ end
 
 function hess_op_residual!(nls :: SlackNLSModel, x :: AbstractVector, i :: Int, Hiv :: AbstractVector)
   prod = @closure v -> hprod_residual!(nls, x, i, v, Hiv)
-  return LinearOperator{Float64}(nls_meta(nls).nvar, nls_meta(nls).nvar,
+  return LinearOperator{eltype(x)}(nls_meta(nls).nvar, nls_meta(nls).nvar,
                                  true, true, prod, prod, prod)
 end

--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -155,6 +155,10 @@ function consistent_functions(nlps; rtol=1.0e-8, exclude=[])
           res = H * v
           @test isapprox(Hvs[i], res, atol=rtol * max(Hvmin, 1.0))
         end
+        if σ == 1 # Check hprod! with default obj_weight
+          hprod!(nlps[i], x, v, tmp_n)
+          @test isapprox(Hvs[i], tmp_n, atol=rtol * max(Hvmin, 1.0))
+        end
       end
     end
   end

--- a/test/multiple-precision.jl
+++ b/test/multiple-precision.jl
@@ -6,14 +6,30 @@ function multiple_precision(nlp :: AbstractNLPModel;
     @test eltype(grad(nlp, x)) == T
     @test eltype(hess(nlp, x)) == T
     @test eltype(hess_op(nlp, x)) == T
+    rows, cols = hess_structure(nlp)
+    vals = hess_coord(nlp, x)
+    @test eltype(vals) == T
+    Hv = zeros(T, nlp.meta.nvar)
+    @test eltype(hess_op!(nlp, rows, cols, vals, Hv)) == T
     if nlp.meta.ncon > 0
       y = ones(T, nlp.meta.ncon)
       @test eltype(cons(nlp, x)) == T
       @test eltype(jac(nlp, x)) == T
       @test eltype(jac_op(nlp, x)) == T
+      rows, cols = jac_structure(nlp)
+      vals = jac_coord(nlp, x)
+      @test eltype(vals) == T
+      Av = zeros(T, nlp.meta.ncon)
+      Atv = zeros(T, nlp.meta.nvar)
+      @test eltype(jac_op!(nlp, rows, cols, vals, Av, Atv)) == T
       @test eltype(hess(nlp, x, y)) == T
       @test eltype(hess(nlp, x, y, obj_weight=one(T))) == T
       @test eltype(hess_op(nlp, x, y)) == T
+      rows, cols = hess_structure(nlp)
+      vals = hess_coord(nlp, x, y)
+      @test eltype(vals) == T
+      Hv = zeros(T, nlp.meta.nvar)
+      @test eltype(hess_op!(nlp, rows, cols, vals, Hv)) == T
     end
   end
 end
@@ -25,6 +41,12 @@ function multiple_precision(nls :: AbstractNLSModel;
     @test eltype(residual(nls, x)) == T
     @test eltype(jac_residual(nls, x)) == T
     @test eltype(jac_op_residual(nls, x)) == T
+    rows, cols = jac_structure_residual(nls)
+    vals = jac_coord_residual(nls, x)
+    @test eltype(vals) == T
+    Av = zeros(T, nls.nls_meta.nequ)
+    Atv = zeros(T, nls.meta.nvar)
+    @test eltype(jac_op!(nls, rows, cols, vals, Av, Atv)) == T
     @test eltype(hess_residual(nls, x, ones(T, nls.nls_meta.nequ))) == T
     for i = 1:nls.nls_meta.nequ
       @test eltype(hess_op_residual(nls, x, i)) == T
@@ -35,6 +57,12 @@ function multiple_precision(nls :: AbstractNLSModel;
       @test eltype(cons(nls, x)) == T
       @test eltype(jac(nls, x)) == T
       @test eltype(jac_op(nls, x)) == T
+      rows, cols = jac_structure(nls)
+      vals = jac_coord(nls, x)
+      @test eltype(vals) == T
+      Av = zeros(T, nls.meta.ncon)
+      Atv = zeros(T, nls.meta.nvar)
+      @test eltype(jac_op!(nls, rows, cols, vals, Av, Atv)) == T
     end
   end
 end

--- a/test/problems/hs10.jl
+++ b/test/problems/hs10.jl
@@ -63,12 +63,6 @@ function NLPModels.hess_coord!(nlp :: HS10, x :: AbstractVector{T}, y :: Abstrac
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS10, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=1.0) where T
-  increment!(nlp, :neval_hprod)
-  fill!(Hv, zero(T))
-  return Hv
-end
-
 function NLPModels.hprod!(nlp :: HS10, x :: AbstractVector, y :: AbstractVector, v :: AbstractVector, Hv :: AbstractVector; obj_weight=1.0)
   increment!(nlp, :neval_hprod)
   Hv[1:nlp.meta.nvar] .= y[1] * [-6 * v[1] + 2 * v[2]; 2 * v[1] - 2 * v[2]]

--- a/test/problems/hs11.jl
+++ b/test/problems/hs11.jl
@@ -62,12 +62,6 @@ function NLPModels.hess_coord!(nlp :: HS11, x :: AbstractVector{T}, y :: Abstrac
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS11, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
-  increment!(nlp, :neval_hprod)
-  Hv .= 2obj_weight * v
-  return Hv
-end
-
 function NLPModels.hprod!(nlp :: HS11, x :: AbstractVector{T}, y :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
   Hv .= 2obj_weight * v

--- a/test/problems/hs14.jl
+++ b/test/problems/hs14.jl
@@ -62,12 +62,6 @@ function NLPModels.hess_coord!(nlp :: HS14, x :: AbstractVector{T}, y :: Abstrac
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS14, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
-  increment!(nlp, :neval_hprod)
-  Hv .= 2obj_weight * v
-  return Hv
-end
-
 function NLPModels.hprod!(nlp :: HS14, x :: AbstractVector{T}, y :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
   Hv .= 2obj_weight * v

--- a/test/problems/hs6.jl
+++ b/test/problems/hs6.jl
@@ -61,12 +61,6 @@ function NLPModels.hess_coord!(nlp :: HS6, x :: AbstractVector{T}, y :: Abstract
   return vals
 end
 
-function NLPModels.hprod!(nlp :: HS6, x :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
-  increment!(nlp, :neval_hprod)
-  Hv .= [2obj_weight * v[1]; 0]
-  return Hv
-end
-
 function NLPModels.hprod!(nlp :: HS6, x :: AbstractVector{T}, y :: AbstractVector{T}, v :: AbstractVector{T}, Hv :: AbstractVector{T}; obj_weight=one(T)) where T
   increment!(nlp, :neval_hprod)
   Hv .= [(2obj_weight - 20y[1]) * v[1]; 0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,22 +28,25 @@ end
 model = DummyModel(NLPModelMeta(1))
 @test_throws(NotImplementedError, lagscale(model, 1.0))
 for meth in [:obj, :varscale, :conscale]
-  @eval @test_throws(NotImplementedError, $meth(model, [0]))
+  @eval @test_throws(NotImplementedError, $meth(model, [0.0]))
 end
-for meth in [:grad!, :cons!, :jac_structure!, :hess_structure!, :jac_coord!, :hess_coord!]
+for meth in [:jac_structure!, :hess_structure!]
   @eval @test_throws(NotImplementedError, $meth(model, [0], [1]))
 end
+for meth in [:grad!, :cons!, :jac_coord!]
+  @eval @test_throws(NotImplementedError, $meth(model, [0.0], [1.0]))
+end
 for meth in [:jth_con, :jth_congrad, :jth_sparse_congrad]
-  @eval @test_throws(NotImplementedError, $meth(model, [0], 1))
+  @eval @test_throws(NotImplementedError, $meth(model, [0.0], 1))
 end
-@test_throws(NotImplementedError, jth_congrad!(model, [0], 1, [2]))
-for meth in [:jprod!, :jtprod!, :hprod!, :hess_coord!]
-  @eval @test_throws(NotImplementedError, $meth(model, [0], [1], [2]))
+@test_throws(NotImplementedError, jth_congrad!(model, [0.0], 1, [2.0]))
+for meth in [:jprod!, :jtprod!]
+  @eval @test_throws(NotImplementedError, $meth(model, [0.0], [1.0], [2.0]))
 end
-@test_throws(NotImplementedError, jth_hprod(model, [0], [1], 2))
-@test_throws(NotImplementedError, jth_hprod!(model, [0], [1], 2, [3]))
-for meth in [:ghjvprod!, :hprod!]
-  @eval @test_throws(NotImplementedError, $meth(model, [0], [1], [2], [3]))
+@test_throws(NotImplementedError, jth_hprod(model, [0.0], [1.0], 2))
+@test_throws(NotImplementedError, jth_hprod!(model, [0.0], [1.0], 2, [3.0]))
+for meth in [:ghjvprod!]
+  @eval @test_throws(NotImplementedError, $meth(model, [0.0], [1.0], [2.0], [3.0]))
 end
 @assert isa(hess_op(model, [0.]), LinearOperator)
 @assert isa(jac_op(model, [0.]), LinearOperator)


### PR DESCRIPTION
Fix missing `eltype(vals)` in #245 and other related multiple precision errors.