### PR TITLE
Add jth_hess_residual implementation

### DIFF
--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -556,7 +556,7 @@ function hprod!(nlp::AbstractNLPModel, rows::AbstractVector{<: Integer}, cols::A
 end
 
 """
-    Hv = hprod!(nlp, x, rows, cols, v, Hv)
+    Hv = hprod!(nlp, x, rows, cols, v, Hv; obj_weight=1.0)
 
 Evaluate the product of the objective Hessian at `x` with the vector `v` in
 place, where the objective Hessian is
@@ -576,7 +576,7 @@ hprod!(nlp::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVect
   throw(NotImplementedError("hprod!"))
 
 """
-    Hv = hprod!(nlp, x, y, rows, cols, v, Hv)
+    Hv = hprod!(nlp, x, y, rows, cols, v, Hv; obj_weight=1.0)
 
 Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
 place, where the Lagrangian Hessian is

--- a/src/NLSModels.jl
+++ b/src/NLSModels.jl
@@ -354,8 +354,11 @@ end
 
 Computes the Hessian of the j-th residual at x.
 """
-function jth_hess_residual(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int)
-  throw(NotImplementedError("jth_hess_residual"))
+function jth_hess_residual(nls :: AbstractNLSModel, x :: AbstractVector, j :: Int)
+  increment!(nls, :neval_jhess_residual)
+  decrement!(nls, :neval_hess_residual)
+  v = [i == j ? one(eltype(x)) : zero(eltype(x)) for i = 1 : nls.nls_meta.nequ]
+  return hess_residual(nls, x, v)
 end
 
 """

--- a/test/test_nlsmodels.jl
+++ b/test/test_nlsmodels.jl
@@ -9,7 +9,6 @@ end
 for mtd in [:jprod_residual!, :jtprod_residual!, :hess_coord_residual!]
   @eval @test_throws(NotImplementedError, $mtd(model, [0], [1], [2]))
 end
-@test_throws(NotImplementedError, jth_hess_residual(model, [0], 1))
 @test_throws(NotImplementedError, hprod_residual!(model, [0], 1, [2], [3]))
 
 include("test_autodiff_nls_model.jl")


### PR DESCRIPTION
Is it possible to merge this before the release 0.12 of NLPModel? I will need it for `NLPModelJuMP`.