### PR TITLE
Remove NotImplemented and use MethodError instead

### DIFF
--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -27,19 +27,11 @@ export reset_data!, reset!, sum_counters,
        jac, jprod, jprod!, jtprod, jtprod!, jac_op, jac_op!,
        jth_hprod, jth_hprod!, ghjvprod, ghjvprod!,
        hess_structure!, hess_structure, hess_coord!, hess_coord, hess, hprod, hprod!, hess_op, hess_op!,
-       push!,
-       varscale, lagscale, conscale,
-       NotImplementedError
+       push!, varscale, lagscale, conscale
 
 # import methods we override
 import Base.push!
 import LinearOperators.reset!
-
-struct NotImplementedError <: Exception
-  name :: Union{Symbol,Function,String}
-end
-
-Base.showerror(io::IO, e::NotImplementedError) = print(io, e.name, " not implemented")
 
 include("nlp_utils.jl")
 include("nlp_types.jl")
@@ -131,8 +123,7 @@ end
 
 Evaluate ``f(x)``, the objective function of `nlp` at `x`.
 """
-obj(::AbstractNLPModel, ::AbstractVector) =
-  throw(NotImplementedError("obj"))
+function obj end
 
 """
     g = grad(nlp, x)
@@ -150,8 +141,7 @@ end
 
 Evaluate ``∇f(x)``, the gradient of the objective function at `x` in place.
 """
-grad!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector) =
-  throw(NotImplementedError("grad!"))
+function grad! end
 
 """
     c = cons(nlp, x)
@@ -169,11 +159,9 @@ end
 
 Evaluate ``c(x)``, the constraints at `x` in place.
 """
-cons!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector) =
-  throw(NotImplementedError("cons!"))
+function cons! end
 
-jth_con(::AbstractNLPModel, ::AbstractVector, ::Integer) =
-  throw(NotImplementedError("jth_con"))
+function jth_con end
 
 function jth_congrad(nlp::AbstractNLPModel, x::AbstractVector, j::Integer)
   @lencheck nlp.meta.nvar x
@@ -181,11 +169,9 @@ function jth_congrad(nlp::AbstractNLPModel, x::AbstractVector, j::Integer)
   return jth_congrad!(nlp, x, j, g)
 end
 
-jth_congrad!(::AbstractNLPModel, ::AbstractVector, ::Integer, ::AbstractVector) =
-  throw(NotImplementedError("jth_congrad!"))
+function jth_congrad! end
 
-jth_sparse_congrad(::AbstractNLPModel, ::AbstractVector, ::Integer) =
-  throw(NotImplementedError("jth_sparse_congrad"))
+function jth_sparse_congrad end
 
 """
     f, c = objcons(nlp, x)
@@ -253,7 +239,7 @@ end
 
 Return the structure of the constraint's Jacobian in sparse coordinate format in place.
 """
-jac_structure!(:: AbstractNLPModel, :: AbstractVector{<:Integer}, :: AbstractVector{<:Integer}) = throw(NotImplementedError("jac_structure!"))
+function jac_structure! end
 
 """
     vals = jac_coord!(nlp, x, vals)
@@ -261,7 +247,7 @@ jac_structure!(:: AbstractNLPModel, :: AbstractVector{<:Integer}, :: AbstractVec
 Evaluate ``J(x)``, the constraint's Jacobian at `x` in sparse coordinate format,
 rewriting `vals`.
 """
-jac_coord!(:: AbstractNLPModel, :: AbstractVector, ::AbstractVector) = throw(NotImplementedError("jac_coord!"))
+function jac_coord! end
 
 """
     vals = jac_coord(nlp, x)
@@ -302,8 +288,7 @@ end
 
 Evaluate ``J(x)v``, the Jacobian-vector product at `x` in place.
 """
-jprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector) =
-  throw(NotImplementedError("jprod!"))
+function jprod! end
 
 """
     Jv = jprod!(nlp, rows, cols, vals, v, Jv)
@@ -344,8 +329,7 @@ end
 
 Evaluate ``J(x)^Tv``, the transposed-Jacobian-vector product at `x` in place.
 """
-jtprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector) =
-  throw(NotImplementedError("jtprod!"))
+function jtprod! end
 
 """
     Jtv = jtprod!(nlp, rows, cols, vals, v, Jtv)
@@ -442,8 +426,7 @@ function jth_hprod(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector, 
   return jth_hprod!(nlp, x, v, j, hv)
 end
 
-jth_hprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::Integer, ::AbstractVector) =
-  throw(NotImplementedError("jth_hprod!"))
+function jth_hprod! end
 
 function ghjvprod(nlp::AbstractNLPModel, x::AbstractVector, g::AbstractVector, v::AbstractVector)
   @lencheck nlp.meta.nvar x g v
@@ -451,8 +434,7 @@ function ghjvprod(nlp::AbstractNLPModel, x::AbstractVector, g::AbstractVector, v
   return ghjvprod!(nlp, x, g, v, gHv)
 end
 
-ghjvprod!(::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector, ::AbstractVector) =
-  throw(NotImplementedError("ghjvprod!"))
+function ghjvprod! end
 
 """
     (rows,cols) = hess_structure(nlp)
@@ -470,7 +452,7 @@ end
 
 Return the structure of the Lagrangian Hessian in sparse coordinate format in place.
 """
-hess_structure!(:: AbstractNLPModel, ::AbstractVector{<: Integer}, ::AbstractVector{<: Integer}) = throw(NotImplementedError("hess_structure!"))
+function hess_structure! end
 
 """
     vals = hess_coord!(nlp, x, vals; obj_weight=1.0)
@@ -494,7 +476,7 @@ with objective function scaled by `obj_weight`, i.e.,
 $(LAGRANGIAN_HESSIAN), rewriting `vals`.
 Only the lower triangle is returned.
 """
-hess_coord!(nlp:: AbstractNLPModel, :: AbstractVector, :: AbstractVector, ::AbstractVector; obj_weight :: Real=one(eltype(x))) = throw(NotImplementedError("hess_coord!"))
+function hess_coord! end
 
 """
     vals = hess_coord(nlp, x; obj_weight=1.0)
@@ -629,8 +611,7 @@ Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
 place, with objective function scaled by `obj_weight`, where the Lagrangian Hessian is
 $(LAGRANGIAN_HESSIAN).
 """
-hprod!(nlp::AbstractNLPModel, ::AbstractVector, ::AbstractVector, ::AbstractVector, ::AbstractVector; obj_weight :: Real=one(eltype(x))) =
-  throw(NotImplementedError("hprod!"))
+function hprod! end
 
 """
     Hv = hprod!(nlp, x, y, rows, cols, v, Hv; obj_weight=1.0)
@@ -764,15 +745,10 @@ function hess_op!(nlp :: AbstractNLPModel, x :: AbstractVector, y :: AbstractVec
   return hess_op!(nlp, rows, cols, vals, Hv)
 end
 
-
-push!(nlp :: AbstractNLPModel, args...; kwargs...) =
-  throw(NotImplementedError("push!"))
-varscale(::AbstractNLPModel, ::AbstractVector) =
-  throw(NotImplementedError("varscale"))
-lagscale(::AbstractNLPModel, ::Real) =
-  throw(NotImplementedError("lagscale"))
-conscale(::AbstractNLPModel, ::AbstractVector) =
-  throw(NotImplementedError("conscale"))
+function push! end
+function varscale end
+function lagscale end
+function conscale end
 
 include("autodiff_model.jl")
 include("slack_model.jl")

--- a/src/NLSModels.jl
+++ b/src/NLSModels.jl
@@ -4,8 +4,7 @@ export AbstractNLSModel, nls_meta, NLSCounters, reset!,
        jtprod_residual, jtprod_residual!, jac_op_residual, jac_op_residual!,
        hess_residual, hess_structure_residual, hess_structure_residual!,
        hess_coord_residual!, hess_coord_residual, jth_hess_residual,
-       hprod_residual, hprod_residual!, hess_op_residual, hess_op_residual!,
-       NotImplementedError
+       hprod_residual, hprod_residual!, hess_op_residual, hess_op_residual!
 
 abstract type AbstractNLSModel <: AbstractNLPModel end
 
@@ -115,9 +114,7 @@ end
 
 Computes ``F(x)``, the residual at x.
 """
-function residual!(nls :: AbstractNLSModel, x :: AbstractVector, Fx :: AbstractVector)
-  throw(NotImplementedError("residual!"))
-end
+function residual! end
 
 """
     Jx = jac_residual(nls, x)
@@ -136,9 +133,7 @@ end
 
 Returns the structure of the constraint's Jacobian in sparse coordinate format in place.
 """
-function jac_structure_residual!(nls :: AbstractNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
-  throw(NotImplementedError("jac_structure_residual!"))
-end
+function jac_structure_residual! end
 
 """
     (rows,cols) = jac_structure_residual(nls)
@@ -157,9 +152,7 @@ end
 Computes the Jacobian of the residual at `x` in sparse coordinate format, rewriting
 `vals`. `rows` and `cols` are not rewritten.
 """
-function jac_coord_residual!(nls :: AbstractNLSModel, x :: AbstractVector, vals :: AbstractVector)
-  throw(NotImplementedError("jac_coord_residual!"))
-end
+function jac_coord_residual! end
 
 """
     (rows,cols,vals) = jac_coord_residual(nls, x)
@@ -188,9 +181,7 @@ end
 
 Computes the product of the Jacobian of the residual at x and a vector, i.e.,  ``J(x)v``, storing it in `Jv`.
 """
-function jprod_residual!(nls :: AbstractNLSModel, x :: AbstractVector, v :: AbstractVector, Jv :: AbstractVector)
-  throw(NotImplementedError("jprod_residual!"))
-end
+function jprod_residual! end
 
 """
     Jv = jprod_residual!(nls, rows, cols, vals, v, Jv)
@@ -236,9 +227,7 @@ end
 
 Computes the product of the transpose of the Jacobian of the residual at x and a vector, i.e.,  ``J(x)^Tv``, storing it in `Jtv`.
 """
-function jtprod_residual!(nls :: AbstractNLSModel, x :: AbstractVector, v :: AbstractVector, Jtv :: AbstractVector)
-  throw(NotImplementedError("jtprod_residual!"))
-end
+function jtprod_residual! end
 
 """
     Jtv = jtprod_residual!(nls, rows, cols, vals, v, Jtv)
@@ -358,9 +347,7 @@ end
 
 Returns the structure of the residual Hessian in place.
 """
-function hess_structure_residual!(nls :: AbstractNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
-  throw(NotImplementedError("hess_structure_residual!"))
-end
+function hess_structure_residual! end
 
 """
     vals = hess_coord_residual!(nls, x, v, vals)
@@ -368,9 +355,7 @@ end
 Computes the linear combination of the Hessians of the residuals at `x` with coefficients
 `v` in sparse coordinate format, rewriting `vals`.
 """
-function hess_coord_residual!(nls :: AbstractNLSModel, x :: AbstractVector, v :: AbstractVector, vals :: AbstractVector)
-  throw(NotImplementedError("hess_coord_residual!"))
-end
+function hess_coord_residual! end
 
 """
     vals = hess_coord_residual(nls, x, v)
@@ -414,9 +399,7 @@ end
 
 Computes the product of the Hessian of the i-th residual at x, times the vector v, and stores it in vector Hiv.
 """
-function hprod_residual!(nls :: AbstractNLSModel, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
-  throw(NotImplementedError("hprod_residual!"))
-end
+function hprod_residual! end
 
 """
     Hop = hess_op_residual(nls, x, i)

--- a/src/autodiff_model.jl
+++ b/src/autodiff_model.jl
@@ -12,7 +12,7 @@ inital estimate to the Lagrangian multipliers can also be provided.
 
 ````
 ADNLPModel(f, x0; lvar = [-∞,…,-∞], uvar = [∞,…,∞], y0 = zeros,
-  c = NotImplemented, lcon = [-∞,…,-∞], ucon = [∞,…,∞], name = "Generic")
+  c = nothing, lcon = [-∞,…,-∞], ucon = [∞,…,∞], name = "Generic")
 ````
 
   - `f` - The objective function ``f``. Should be callable;
@@ -54,7 +54,7 @@ show_header(io :: IO, nlp :: ADNLPModel) = println(io, "ADNLPModel - Model with 
 function ADNLPModel(f, x0::AbstractVector; y0::AbstractVector = eltype(x0)[],
                     lvar::AbstractVector = eltype(x0)[], uvar::AbstractVector = eltype(x0)[],
                     lcon::AbstractVector = eltype(x0)[], ucon::AbstractVector = eltype(x0)[],
-                    c = (args...)->throw(NotImplementedError("cons")),
+                    c = nothing,
                     name::String = "Generic", lin::AbstractVector{<: Integer}=Int[])
 
   nvar = length(x0)

--- a/src/autodiff_nlsmodel.jl
+++ b/src/autodiff_nlsmodel.jl
@@ -7,7 +7,7 @@ compute the derivatives.
 
 ````
 ADNLSModel(F, x0, m; lvar = [-∞,…,-∞], uvar = [∞,…,∞], y0 = zeros,
-  c = NotImplemented, lcon = [-∞,…,-∞], ucon = [∞,…,∞], name = "Generic")
+  c = nothing, lcon = [-∞,…,-∞], ucon = [∞,…,∞], name = "Generic")
 ````
 
   - `F` - The residual function \$F\$. Should be callable;
@@ -33,7 +33,7 @@ function ADNLSModel(F, x0 :: AbstractVector, m :: Int;
                     name :: String = "Generic",
                     lvar :: AbstractVector = fill(-eltype(x0)(Inf), length(x0)),
                     uvar :: AbstractVector = fill( eltype(x0)(Inf), length(x0)),
-                    c = (args...)->throw(NotImplementedError("cons")),
+                    c = nothing,
                     lcon :: AbstractVector = eltype(x0)[],
                     ucon :: AbstractVector = eltype(x0)[],
                     y0 :: AbstractVector = zeros(eltype(x0), max(length(lcon), length(ucon))),

--- a/src/autodiff_nlsmodel.jl
+++ b/src/autodiff_nlsmodel.jl
@@ -7,7 +7,7 @@ compute the derivatives.
 
 ````
 ADNLSModel(F, x0, m; lvar = [-∞,…,-∞], uvar = [∞,…,∞], y0 = zeros,
-  c = nothing, lcon = [-∞,…,-∞], ucon = [∞,…,∞], name = "Generic")
+  c = x->[], lcon = [], ucon = [], name = "Generic")
 ````
 
   - `F` - The residual function \$F\$. Should be callable;
@@ -33,18 +33,20 @@ function ADNLSModel(F, x0 :: AbstractVector, m :: Int;
                     name :: String = "Generic",
                     lvar :: AbstractVector = fill(-eltype(x0)(Inf), length(x0)),
                     uvar :: AbstractVector = fill( eltype(x0)(Inf), length(x0)),
-                    c = nothing,
+                    c = x -> eltype(x0)[],
                     lcon :: AbstractVector = eltype(x0)[],
                     ucon :: AbstractVector = eltype(x0)[],
-                    y0 :: AbstractVector = zeros(eltype(x0), max(length(lcon), length(ucon))),
+                    y0 :: AbstractVector = eltype(x0)[],
                     lin :: AbstractVector{<: Integer} = Int[],
                     linequ :: AbstractVector{<: Integer} = Int[],
                    )
+  T = eltype(x0)
   nvar = length(x0)
   ncon = maximum([length(lcon); length(ucon); length(y0)])
-  if !(length(lcon) == length(ucon) == length(y0))
-    error("lcon, ucon and y0 need to be the same length")
-  end
+  length(lcon) == 0 && (lcon = fill(-T(Inf), ncon))
+  length(ucon) == 0 && (ucon = fill(T(Inf), ncon))
+  length(y0) == 0 && (y0 = zeros(T, ncon))
+  @lencheck ncon lcon ucon y0
   nnzj = nvar * ncon
 
   nln = setdiff(1:ncon, lin)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,32 +21,32 @@ print(ADNLPModel(x->0, zeros(10), c=x->[0.0;0.0;0.0], lcon=[0.0;0.0;-Inf],
 # A problem with zero variables doesn't make sense.
 @test_throws(ErrorException, NLPModelMeta(0))
 
-# Default methods should throw NotImplementedError.
+# Default methods should throw MethodError since they're not defined
 mutable struct DummyModel <: AbstractNLPModel
   meta :: NLPModelMeta
 end
 model = DummyModel(NLPModelMeta(1))
-@test_throws(NotImplementedError, lagscale(model, 1.0))
+@test_throws(MethodError, lagscale(model, 1.0))
 for meth in [:obj, :varscale, :conscale]
-  @eval @test_throws(NotImplementedError, $meth(model, [0.0]))
+  @eval @test_throws(MethodError, $meth(model, [0.0]))
 end
 for meth in [:jac_structure!, :hess_structure!]
-  @eval @test_throws(NotImplementedError, $meth(model, [0], [1]))
+  @eval @test_throws(MethodError, $meth(model, [0], [1]))
 end
 for meth in [:grad!, :cons!, :jac_coord!]
-  @eval @test_throws(NotImplementedError, $meth(model, [0.0], [1.0]))
+  @eval @test_throws(MethodError, $meth(model, [0.0], [1.0]))
 end
 for meth in [:jth_con, :jth_congrad, :jth_sparse_congrad]
-  @eval @test_throws(NotImplementedError, $meth(model, [0.0], 1))
+  @eval @test_throws(MethodError, $meth(model, [0.0], 1))
 end
-@test_throws(NotImplementedError, jth_congrad!(model, [0.0], 1, [2.0]))
+@test_throws(MethodError, jth_congrad!(model, [0.0], 1, [2.0]))
 for meth in [:jprod!, :jtprod!]
-  @eval @test_throws(NotImplementedError, $meth(model, [0.0], [1.0], [2.0]))
+  @eval @test_throws(MethodError, $meth(model, [0.0], [1.0], [2.0]))
 end
-@test_throws(NotImplementedError, jth_hprod(model, [0.0], [1.0], 2))
-@test_throws(NotImplementedError, jth_hprod!(model, [0.0], [1.0], 2, [3.0]))
+@test_throws(MethodError, jth_hprod(model, [0.0], [1.0], 2))
+@test_throws(MethodError, jth_hprod!(model, [0.0], [1.0], 2, [3.0]))
 for meth in [:ghjvprod!]
-  @eval @test_throws(NotImplementedError, $meth(model, [0.0], [1.0], [2.0], [3.0]))
+  @eval @test_throws(MethodError, $meth(model, [0.0], [1.0], [2.0], [3.0]))
 end
 @assert isa(hess_op(model, [0.]), LinearOperator)
 @assert isa(jac_op(model, [0.]), LinearOperator)
@@ -66,7 +66,7 @@ obj(model, model.meta.x0)
 reset!(model)
 @assert neval_obj(model) == 0
 
-@test_throws(NotImplementedError, jth_con(model, model.meta.x0, 1))
+@test_throws(MethodError, jth_con(model, model.meta.x0, 1))
 
 include("test_tools.jl")
 

--- a/test/test_autodiff_model.jl
+++ b/test/test_autodiff_model.jl
@@ -24,6 +24,20 @@ function test_autodiff_model()
   β = [ones(100) x] \ y
   @test abs(obj(nlp, β) - norm(y .- β[1] - β[2] * x)^2 / 2) < 1e-12
   @test norm(grad(nlp, β)) < 1e-12
+
+  # Testing input
+  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0])
+  nlp = ADNLPModel(f, x0, c=c, ucon=[0.0])
+  nlp = ADNLPModel(f, x0, c=c, y0=[0.0])
+  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0])
+  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0], y0=[0.0])
+  nlp = ADNLPModel(f, x0, c=c, ucon=[0.0], y0=[0.0])
+  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0], y0=[0.0])
+  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0; 0.0])
+  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0; 0.0], ucon=[0.0])
+  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0; 0.0], y0=[0.0])
+  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0; 0.0], ucon=[0.0], y0=[0.0])
+  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0], y0=[0.0; 0.0])
 end
 
 test_autodiff_model()

--- a/test/test_nlsmodels.jl
+++ b/test/test_nlsmodels.jl
@@ -4,12 +4,12 @@ end
 model = DummyNLSModel()
 
 for mtd in [:residual!, :jac_structure_residual!, :jac_coord_residual!, :hess_structure_residual!]
-  @eval @test_throws(NotImplementedError, $mtd(model, [0], [1]))
+  @eval @test_throws(MethodError, $mtd(model, [0], [1]))
 end
 for mtd in [:jprod_residual!, :jtprod_residual!, :hess_coord_residual!]
-  @eval @test_throws(NotImplementedError, $mtd(model, [0], [1], [2]))
+  @eval @test_throws(MethodError, $mtd(model, [0], [1], [2]))
 end
-@test_throws(NotImplementedError, hprod_residual!(model, [0], 1, [2], [3]))
+@test_throws(MethodError, hprod_residual!(model, [0], 1, [2], [3]))
 
 include("test_autodiff_nls_model.jl")
 include("test_lls_model.jl")


### PR DESCRIPTION
Following this idea: https://white.ucc.asn.au/2020/04/19/Julia-Antipatterns.html
I also noticed an unnecessary computation of Hessians in `ADNLPModel`, I guess from the time we computed the sparsity of the Hessian there.