### PR TITLE
Implement variants for LLSModel

### DIFF
--- a/src/lls_model.jl
+++ b/src/lls_model.jl
@@ -58,7 +58,7 @@ function LLSModel end
 
 function LLSMatrixModel(A :: AbstractMatrix, b :: AbstractVector;
                         x0 :: AbstractVector = zeros(eltype(A), size(A,2)),
-                        lvar :: AbstractVector = fill(-eltype(A)(Inf), size(A, 2)),
+                        lvar :: AbstractVector = fill(eltype(A)(-Inf), size(A, 2)),
                         uvar :: AbstractVector = fill(eltype(A)(Inf), size(A, 2)),
                         C :: AbstractMatrix  = Matrix{eltype(A)}(undef, 0, 0),
                         lcon :: AbstractVector = eltype(A)[],
@@ -80,7 +80,7 @@ end
 
 function LLSOperatorModel(A :: LinearOperator, b :: AbstractVector;
                           x0 :: AbstractVector = zeros(eltype(A), size(A,2)),
-                          lvar :: AbstractVector = fill(-eltype(A)(Inf), size(A, 2)),
+                          lvar :: AbstractVector = fill(eltype(A)(-Inf), size(A, 2)),
                           uvar :: AbstractVector = fill(eltype(A)(Inf), size(A, 2)),
                           C :: LinearOperator  = opZeros(eltype(A), 0, size(A, 2)),
                           lcon :: AbstractVector = eltype(A)[],
@@ -103,7 +103,7 @@ function LLSTripletModel(Arows :: AbstractVector{<: Integer},
                          nvar :: Integer,
                          b :: AbstractVector;
                          x0 :: AbstractVector = zeros(eltype(Avals), nvar),
-                         lvar :: AbstractVector = fill(-eltype(Avals)(Inf), nvar),
+                         lvar :: AbstractVector = fill(eltype(Avals)(-Inf), nvar),
                          uvar :: AbstractVector = fill(eltype(Avals)(Inf), nvar),
                          Crows :: AbstractVector{<: Integer} = eltype(Arows)[],
                          Ccols :: AbstractVector{<: Integer} = eltype(Arows)[],
@@ -132,7 +132,7 @@ end
 function LLSModel(A :: AbstractMatrix, b :: AbstractVector;
                   variant = :matrix, kwargs...)
   if !(variant in [:matrix, :operator, :triplet])
-    error("variant should be one of [:matrix, :operator, :triplet")
+    error("variant should be one of :matrix, :operator, :triplet")
   end
   LLSModel(Val(variant), A, b; kwargs...)
 end
@@ -142,28 +142,15 @@ function LLSModel(::Val{:matrix}, A :: AbstractMatrix, b :: AbstractVector; kwar
 end
 
 function LLSModel(::Val{:operator}, A :: AbstractMatrix, b :: AbstractVector;
-                  x0 :: AbstractVector = zeros(size(A,2)),
-                  lvar :: AbstractVector = fill(-eltype(A)(Inf), size(A, 2)),
-                  uvar :: AbstractVector = fill(eltype(A)(Inf), size(A, 2)),
                   C :: AbstractMatrix  = Matrix{eltype(A)}(undef, 0, 0),
-                  lcon :: AbstractVector = eltype(A)[],
-                  ucon :: AbstractVector = eltype(A)[],
-                  y0 :: AbstractVector = zeros(eltype(A), size(C,1)),
-                  name :: String = "generic-LLSModel"
+                  kwargs...
                  )
-  LLSOperatorModel(LinearOperator(A), b, x0=x0, lvar=lvar, uvar=uvar,
-                   C=LinearOperator(C), lcon=lcon, ucon=ucon, y0=y0, name=name)
+  LLSOperatorModel(LinearOperator(A), b; C=LinearOperator(C), kwargs...)
 end
 
 function LLSModel(::Val{:triplet}, A :: AbstractMatrix, b :: AbstractVector;
-                  x0 :: AbstractVector = zeros(size(A,2)),
-                  lvar :: AbstractVector = fill(-eltype(A)(Inf), size(A, 2)),
-                  uvar :: AbstractVector = fill(eltype(A)(Inf), size(A, 2)),
                   C :: AbstractMatrix  = Matrix{eltype(A)}(undef, 0, 0),
-                  lcon :: AbstractVector = eltype(A)[],
-                  ucon :: AbstractVector = eltype(A)[],
-                  y0 :: AbstractVector = zeros(eltype(A), size(C,1)),
-                  name :: String = "generic-LLSModel"
+                  kwargs...
                  )
   nvar = size(A, 2)
   Arows, Acols, Avals = if A isa AbstractSparseMatrix
@@ -180,8 +167,7 @@ function LLSModel(::Val{:triplet}, A :: AbstractMatrix, b :: AbstractVector;
     I = ((i,j) for i = 1:m, j = 1:n)
     getindex.(I, 1)[:], getindex.(I, 2)[:], C[:]
   end
-  LLSTripletModel(Arows, Acols, Avals, nvar, b, x0=x0, lvar=lvar, uvar=uvar,
-                  Crows=Crows, Ccols=Ccols, Cvals=Cvals, lcon=lcon, ucon=ucon, y0=y0, name=name)
+  LLSTripletModel(Arows, Acols, Avals, nvar, b; Crows=Crows, Ccols=Ccols, Cvals=Cvals, kwargs...)
 end
 
 function LLSModel(A :: LinearOperator, b :: AbstractVector; kwargs...)
@@ -195,7 +181,7 @@ function LLSModel(Arows :: AbstractVector{<: Integer},
                   b :: AbstractVector;
                   variant=:triplet, kwargs...)
   if !(variant in [:matrix, :operator, :triplet])
-    error("variant should be one of [:matrix, :operator, :triplet")
+    error("variant should be one of :matrix, :operator, :triplet")
   end
   LLSModel(Val(variant), Arows, Acols, Avals, nvar, b; kwargs...)
 end
@@ -207,7 +193,7 @@ function LLSModel(::Val{:matrix},
                   nvar :: Integer,
                   b :: AbstractVector;
                   x0 :: AbstractVector = zeros(eltype(Avals), nvar),
-                  lvar :: AbstractVector = fill(-eltype(Avals)(Inf), nvar),
+                  lvar :: AbstractVector = fill(eltype(Avals)(-Inf), nvar),
                   uvar :: AbstractVector = fill(eltype(Avals)(Inf), nvar),
                   Crows :: AbstractVector{<: Integer} = eltype(Arows)[],
                   Ccols :: AbstractVector{<: Integer} = eltype(Arows)[],
@@ -232,8 +218,8 @@ function LLSModel(::Val{:operator},
                   Avals :: AbstractVector,
                   nvar :: Integer,
                   b :: AbstractVector;
-                  x0 :: AbstractVector = zeros(nvar),
-                  lvar :: AbstractVector = fill(-eltype(Avals)(Inf), nvar),
+                  x0 :: AbstractVector = zeros(eltype(Avals), nvar),
+                  lvar :: AbstractVector = fill(eltype(Avals)(-Inf), nvar),
                   uvar :: AbstractVector = fill(eltype(Avals)(Inf), nvar),
                   Crows :: AbstractVector{<: Integer} = eltype(Arows)[],
                   Ccols :: AbstractVector{<: Integer} = eltype(Arows)[],

--- a/src/lls_model.jl
+++ b/src/lls_model.jl
@@ -238,7 +238,7 @@ function LLSModel(::Val{:operator},
   @lencheck nnzj Crows Ccols
   nequ = length(b)
 
-  TA, TC = eltype(Avals), eltype(Acols)
+  TA, TC = eltype(Avals), eltype(Cvals)
   Av = zeros(TA, nequ)
   Atv = zeros(TA, nvar)
   Aprod(v)  = coo_prod!(Arows, Acols, Avals, v, Av)
@@ -557,10 +557,10 @@ function hess_coord!(nls :: LLSMatrixModel, x :: AbstractVector, vals :: Abstrac
   increment!(nls, :neval_hess)
   AtA = tril(nls.A' * nls.A)
   if issparse(AtA)
-    vals .= AtA.nzval
+    vals .= obj_weight * AtA.nzval
   else
     n = size(nls.A, 2)
-    vals .= (AtA[i,j] for i = 1:n, j = 1:n if i ≥ j)
+    vals .= (obj_weight * AtA[i,j] for i = 1:n, j = 1:n if i ≥ j)
   end
   return vals
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,8 +129,8 @@ for problem in nls_problems
     check_nlp_dimensions(nls, exclude_hess=true)
   end
 
-  # LLSModel returns the internal A for jac, hence it doesn't respect type input
-  idx = findall(typeof.(nlss) .== LLSModel)
+  # AbstractLLSModels returns the internal A for jac, hence it doesn't respect type input
+  idx = findall([typeof(nls) <: AbstractLLSModel for nls in nlss])
   if length(idx) > 0
     deleteat!(nlss, idx)
   end

--- a/test/test_lls_model.jl
+++ b/test/test_lls_model.jl
@@ -1,32 +1,60 @@
 function lls_test()
+  constructors = [("matrices", (A, b, C; kwargs...) -> LLSModel(A, b; C=C, kwargs...)),
+                  ("triplet format", (A, b, C; kwargs...) -> begin
+                     fA = findnz(sparse(A))
+                     fC = findnz(sparse(C))
+                     LLSModel(fA..., size(A, 2), b; Crows=fC[1], Ccols=fC[2], Cvals=fC[3], kwargs...)
+                   end)
+                 ]
+  types_per_variant = Dict(:matrix => LLSMatrixModel,
+                           :operator => LLSOperatorModel,
+                           :triplet => LLSTripletModel)
   @testset "lls_test" begin
-    for A = [Matrix(1.0I, 10, 3) .+ 1, sparse(1.0I, 10, 3) .+ 1],
-        C = [ones(1, 3), [ones(1,3); -I], sparse(ones(1,3))]
-      b = collect(1:10)
-      nequ, nvar = size(A)
-      ncon = size(C,1)
-      nls = LLSModel(A, b, C=C, lcon=zeros(ncon), ucon=zeros(ncon))
-      x = [1.0; -1.0; 1.0]
+    for variant in [:matrix, :operator, :triplet], (name, con) in constructors
+      @testset "Constructor from $name variant=$variant" begin
+        for A = [Matrix(1.0I, 10, 3) .+ 1, sparse(1.0I, 10, 3) .+ 1],
+            C = [zeros(0, 3), ones(1, 3), [ones(1,3); -I], sparse(ones(1,3))]
 
-      @test isapprox(A * x - b, residual(nls, x), rtol=1e-8)
-      @test A == jac_residual(nls, x)
-      I, J = jac_structure_residual(nls)
-      V = jac_coord_residual(nls, x)
-      @test A == sparse(I, J, V, nequ, nvar)
-      I, J = hess_structure_residual(nls)
-      V = hess_coord_residual(nls, x, ones(nequ))
-      @test sparse(I, J, V, nvar, nvar) == zeros(nvar, nvar)
-      @test hess_residual(nls, x, ones(nequ)) == zeros(nvar,nvar)
-      for i = 1:nequ
-        @test isapprox(zeros(nvar, nvar), jth_hess_residual(nls, x, i), rtol=1e-8)
+          b = collect(1:10)
+          nequ, nvar = size(A)
+          ncon = size(C,1)
+
+          nls = con(A, b, C, variant=variant, lcon=zeros(ncon), ucon=zeros(ncon))
+          @test typeof(nls) == types_per_variant[variant]
+
+          x = [1.0; -1.0; 1.0]
+          @test isapprox(A * x - b, residual(nls, x), rtol=1e-8)
+          I, J = hess_structure_residual(nls)
+          V = hess_coord_residual(nls, x, ones(nequ))
+          @test sparse(I, J, V, nvar, nvar) == zeros(nvar, nvar)
+          @test hess_residual(nls, x, ones(nequ)) == zeros(nvar,nvar)
+          for i = 1:nequ
+            @test isapprox(zeros(nvar, nvar), jth_hess_residual(nls, x, i), rtol=1e-8)
+          end
+
+          @test nls.meta.nlin == length(nls.meta.lin) == ncon
+          @test nls.meta.nnln == length(nls.meta.nln) == 0
+
+          if variant != :operator
+            @test A == jac_residual(nls, x)
+            I, J = jac_structure_residual(nls)
+            V = jac_coord_residual(nls, x)
+            @test A == sparse(I, J, V, nequ, nvar)
+
+            @test C == jac(nls, x)
+            I, J = jac_structure(nls)
+            V = jac_coord(nls, x)
+            @test C == sparse(I, J, V, ncon, nvar)
+          end
+        end
       end
+    end
 
-      I, J = jac_structure(nls)
-      V = jac_coord(nls, x)
-      @test sparse(I, J, V, ncon, nvar) == C
-
-      @test nls.meta.nlin == length(nls.meta.lin) == ncon
-      @test nls.meta.nnln == length(nls.meta.nln) == 0
+    @testset "Other constructors" begin
+      A = LinearOperator(rand(10, 3))
+      b = rand(10)
+      C = LinearOperator(rand(1, 3))
+      nls = LLSModel(A, b, C=C, lcon=[0.0], ucon=[0.0])
     end
   end
 end

--- a/test/test_lls_model.jl
+++ b/test/test_lls_model.jl
@@ -56,6 +56,24 @@ function lls_test()
       C = LinearOperator(rand(1, 3))
       nls = LLSModel(A, b, C=C, lcon=[0.0], ucon=[0.0])
     end
+
+    @testset "Hess related functions" begin
+      b = rand(10)
+      A = rand(10, 5)
+      AtA = A' * A
+      lls = LLSModel(A, b)
+      I, J = hess_structure(lls)
+      V = hess_coord(lls, lls.meta.x0)
+      ijv = ((i,j,AtA[i,j]) for i = 1:5, j = 1:5 if i ≥ j)
+      @test I == getindex.(ijv, 1)
+      @test J == getindex.(ijv, 2)
+      @test V == getindex.(ijv, 3)
+      A = sprand(10, 5, 0.2)
+      lls = LLSModel(A, b)
+      I, J = hess_structure(lls)
+      V = hess_coord(lls, lls.meta.x0)
+      @test (I, J, V) == findnz(tril(A' * A))
+    end
   end
 end
 


### PR DESCRIPTION
This should help tackle #273 and #281. These constructors are available now
```julia
    nls = LLSModel(A, b; lvar, uvar, C, lcon, ucon, variant)
    nls = LLSModel(opA, b; lvar, uvar, opC, lcon, ucon)
    nls = LLSModel(Arows, Acols, Avals, b; lvar, uvar, Crows, Ccols, Cvals, lcon, ucon, variant)
```
with the `variant` option allowing conversion between internal types. `variant` can be `:matrix`, `:operator` or `:triplet`.
Disclaimers:
- The operator input is not automatically converted to matrices. `Matrix(opA)` should allow that.
- Only the first option implements `hess`, since it's only `A' * A`. If `A` is sparse, `nnzh` is computed using `nnz(tril(A' * A))`, so there is a cost at construction.

@vepiteski, can you test that these work for your issues?