### PR TITLE
Remove jth_hess_residual, hess and jac implementations for test models

### DIFF
--- a/test/nls_problems/lls.jl
+++ b/test/nls_problems/lls.jl
@@ -82,12 +82,6 @@ function NLPModels.hess_coord_residual!(nls :: LLS, x :: AbstractVector, v :: Ab
   return vals
 end
 
-function NLPModels.jth_hess_residual(nls :: LLS, x :: AbstractVector, j :: Int)
-  @lencheck 2 x
-  increment!(nls, :neval_jhess_residual)
-  return zeros(eltype(x), 2, 2)
-end
-
 function NLPModels.hprod_residual!(nls :: LLS, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
   @lencheck 2 x v Hiv
   increment!(nls, :neval_hprod_residual)

--- a/test/nls_problems/mgh01.jl
+++ b/test/nls_problems/mgh01.jl
@@ -75,16 +75,6 @@ function NLPModels.hess_coord_residual!(nls :: MGH01, x :: AbstractVector, v :: 
   return vals
 end
 
-function NLPModels.jth_hess_residual(nls :: MGH01, x :: AbstractVector, j :: Int)
-  @lencheck 2 x
-  increment!(nls, :neval_jhess_residual)
-  if j == 1
-    return eltype(x)[-20 0; 0 0]
-  else
-    return zeros(eltype(x), 2, 2)
-  end
-end
-
 function NLPModels.hprod_residual!(nls :: MGH01, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
   @lencheck 2 x v Hiv
   increment!(nls, :neval_hprod_residual)

--- a/test/nls_problems/nlshs20.jl
+++ b/test/nls_problems/nlshs20.jl
@@ -78,16 +78,6 @@ function NLPModels.hess_coord_residual!(nls :: NLSHS20, x :: AbstractVector, v :
   return vals
 end
 
-function NLPModels.jth_hess_residual(nls :: NLSHS20, x :: AbstractVector, j :: Int)
-  @lencheck 2 x
-  increment!(nls, :neval_jhess_residual)
-  if j == 1
-    return eltype(x)[-20 0; 0 0]
-  else
-    return zeros(eltype(x), 2, 2)
-  end
-end
-
 function NLPModels.hprod_residual!(nls :: NLSHS20, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
   @lencheck 2 x v Hiv
   increment!(nls, :neval_hprod_residual)

--- a/test/nls_problems/nlslc.jl
+++ b/test/nls_problems/nlslc.jl
@@ -91,14 +91,6 @@ function NLPModels.hess_coord_residual!(nls :: NLSLC, x :: AbstractVector, v :: 
   return vals
 end
 
-function NLPModels.jth_hess_residual(nls :: NLSLC, x :: AbstractVector, j :: Int)
-  @lencheck 15 x
-  increment!(nls, :neval_jhess_residual)
-  H = zeros(eltype(x), nls.nls_meta.nvar, nls.nls_meta.nvar)
-  H[j,j] = 2
-  return H
-end
-
 function NLPModels.hprod_residual!(nls :: NLSLC, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
   @lencheck 15 x v Hiv
   increment!(nls, :neval_hprod_residual)

--- a/test/problems/hs10.jl
+++ b/test/problems/hs10.jl
@@ -37,19 +37,6 @@ function NLPModels.grad!(nlp :: HS10, x :: AbstractVector{T}, gx :: AbstractVect
   return gx
 end
 
-function NLPModels.hess(nlp :: HS10, x :: AbstractVector{T}; obj_weight=1.0) where T
-  @lencheck 2 x
-  increment!(nlp, :neval_hess)
-  return spzeros(T, 2, 2)
-end
-
-function NLPModels.hess(nlp :: HS10, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=1.0) where T
-  @lencheck 2 x
-  @lencheck 1 y
-  increment!(nlp, :neval_hess)
-  return y[1] * T[-6.0  0.0; 2.0  -2.0]
-end
-
 function NLPModels.hess_structure!(nlp :: HS10, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
   @lencheck 3 rows cols
   rows[1] = 1; rows[2] = 2; rows[3] = 2
@@ -88,12 +75,6 @@ function NLPModels.cons!(nlp :: HS10, x :: AbstractVector, cx :: AbstractVector)
   increment!(nlp, :neval_cons)
   cx .= [-3 * x[1]^2 + 2 * x[1] * x[2] - x[2]^2 + 1]
   return cx
-end
-
-function NLPModels.jac(nlp :: HS10, x :: AbstractVector)
-  @lencheck 2 x
-  increment!(nlp, :neval_jac)
-  return [-6 * x[1] + 2 * x[2]   2 * x[1] - 2 * x[2]]
 end
 
 function NLPModels.jac_structure!(nlp :: HS10, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})

--- a/test/problems/hs11.jl
+++ b/test/problems/hs11.jl
@@ -35,19 +35,6 @@ function NLPModels.grad!(nlp :: HS11, x :: AbstractVector, gx :: AbstractVector)
   return gx
 end
 
-function NLPModels.hess(nlp :: HS11, x :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 2 x
-  increment!(nlp, :neval_hess)
-  return T[2 0; 0 2] * obj_weight
-end
-
-function NLPModels.hess(nlp :: HS11, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 2 x
-  @lencheck 1 y
-  increment!(nlp, :neval_hess)
-  return y[1] * T[-2 0; 0 0] + 2obj_weight*I
-end
-
 function NLPModels.hess_structure!(nlp :: HS11, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
   @lencheck 2 rows cols
   rows[1] = 1; rows[2] = 2
@@ -86,12 +73,6 @@ function NLPModels.cons!(nlp :: HS11, x :: AbstractVector, cx :: AbstractVector)
   increment!(nlp, :neval_cons)
   cx .= [-x[1]^2 + x[2]]
   return cx
-end
-
-function NLPModels.jac(nlp :: HS11, x :: AbstractVector)
-  @lencheck 2 x
-  increment!(nlp, :neval_jac)
-  return [-2 * x[1]  1]
 end
 
 function NLPModels.jac_structure!(nlp :: HS11, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})

--- a/test/problems/hs14.jl
+++ b/test/problems/hs14.jl
@@ -34,18 +34,6 @@ function NLPModels.grad!(nlp :: HS14, x :: AbstractVector, gx :: AbstractVector)
   return gx
 end
 
-function NLPModels.hess(nlp :: HS14, x :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 2 x
-  increment!(nlp, :neval_hess)
-  return T[2 0; 0 2] * obj_weight
-end
-
-function NLPModels.hess(nlp :: HS14, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 2 x y
-  increment!(nlp, :neval_hess)
-  return y[2] * T[-0.5 0.0; 0.0 -2.0] + 2obj_weight * I
-end
-
 function NLPModels.hess_structure!(nlp :: HS14, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
   @lencheck 2 rows cols
   rows[1] = 1; rows[2] = 2
@@ -83,12 +71,6 @@ function NLPModels.cons!(nlp :: HS14, x :: AbstractVector, cx :: AbstractVector)
   increment!(nlp, :neval_cons)
   cx .= [x[1] - 2 * x[2] + 1; -x[1]^2/4 - x[2]^2 + 1]
   return cx
-end
-
-function NLPModels.jac(nlp :: HS14, x :: AbstractVector)
-  @lencheck 2 x
-  increment!(nlp, :neval_jac)
-  return [1 -2; -x[1] / 2  -2 * x[2]]
 end
 
 function NLPModels.jac_structure!(nlp :: HS14, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})

--- a/test/problems/hs5.jl
+++ b/test/problems/hs5.jl
@@ -35,27 +35,20 @@ function NLPModels.grad!(nlp :: HS5, x :: AbstractVector{T}, gx :: AbstractVecto
   return gx
 end
 
-function NLPModels.hess(nlp :: HS5, x :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 2 x
-  increment!(nlp, :neval_hess)
-  return tril(-sin(x[1] + x[2])*ones(T, 2, 2) + T[2 -2; -2 2]) * obj_weight
-end
-
 function NLPModels.hess_structure!(nlp :: HS5, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
   @lencheck 3 rows cols
-  I = ((i,j) for i = 1:nlp.meta.nvar, j = 1:nlp.meta.nvar if i ≥ j)
-  rows .= getindex.(I, 1)
-  cols .= getindex.(I, 2)
+  rows .= [1; 2; 2]
+  cols .= [1; 1; 2]
   return rows, cols
 end
 
 function NLPModels.hess_coord!(nlp :: HS5, x :: AbstractVector, vals :: AbstractVector; obj_weight=1.0)
   @lencheck 2 x
   @lencheck 3 vals
-  H = hess(nlp, x, obj_weight=obj_weight)
-  vals[1] = H[1,1]
-  vals[2] = H[2,1]
-  vals[3] = H[2,2]
+  increment!(nlp, :neval_hess)
+  vals[1] = vals[3] = -sin(x[1] + x[2]) + 2
+  vals[2] = -sin(x[1] + x[2]) - 2
+  vals .*= obj_weight
   return vals
 end
 

--- a/test/problems/hs6.jl
+++ b/test/problems/hs6.jl
@@ -35,19 +35,6 @@ function NLPModels.grad!(nlp :: HS6, x :: AbstractVector, gx :: AbstractVector)
   return gx
 end
 
-function NLPModels.hess(nlp :: HS6, x :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 2 x
-  increment!(nlp, :neval_hess)
-  return [2obj_weight  0; 0 0]
-end
-
-function NLPModels.hess(nlp :: HS6, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 2 x
-  @lencheck 1 y
-  increment!(nlp, :neval_hess)
-  return [2obj_weight - 20y[1]   0; 0 0]
-end
-
 function NLPModels.hess_structure!(nlp :: HS6, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
   @lencheck 1 rows cols
   rows[1] = 1
@@ -85,12 +72,6 @@ function NLPModels.cons!(nlp :: HS6, x :: AbstractVector, cx :: AbstractVector)
   increment!(nlp, :neval_cons)
   cx[1] = 10 * (x[2] - x[1]^2)
   return cx
-end
-
-function NLPModels.jac(nlp :: HS6, x :: AbstractVector)
-  @lencheck 2 x
-  increment!(nlp, :neval_jac)
-  return [-20 * x[1]  10]
 end
 
 function NLPModels.jac_structure!(nlp :: HS6, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})

--- a/test/problems/lincon.jl
+++ b/test/problems/lincon.jl
@@ -47,18 +47,6 @@ function NLPModels.grad!(nlp :: LINCON, x :: AbstractVector, gx :: AbstractVecto
   return gx
 end
 
-function NLPModels.hess(nlp :: LINCON, x :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 15 x
-  increment!(nlp, :neval_hess)
-  return obj_weight * diagm([12 * x[i]^2 for i=1:nlp.meta.nvar])
-end
-
-function NLPModels.hess(nlp :: LINCON, x :: AbstractVector{T}, y :: AbstractVector{T}; obj_weight=one(T)) where T
-  @lencheck 15 x
-  @lencheck 11 y
-  hess(nlp, x; obj_weight=obj_weight)
-end
-
 function NLPModels.hess_structure!(nlp :: LINCON, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})
   @lencheck 15 rows cols
   for i = 1:nlp.meta.nnzh
@@ -105,20 +93,6 @@ function NLPModels.cons!(nlp :: LINCON, x :: AbstractVector, cx :: AbstractVecto
         [1 2; 3 4] * x[1:2];
         diagm([3 * i for i = 3:5]) * x[3:5]]
   return cx
-end
-
-function NLPModels.jac(nlp :: LINCON, x :: AbstractVector)
-  @lencheck 15 x
-  increment!(nlp, :neval_jac)
-  J = spzeros(eltype(x), nlp.meta.ncon, nlp.meta.nvar)
-  J[1,15]     = 15
-  J[2,10:12]  = [1; 2; 3]
-  J[3,13:14]  = [1; -1]
-  J[4,8:9]    = [5; 6]
-  J[5:6,6:7]  = [0 -2; 4 0]
-  J[7:8,1:2]  = [1 2; 3 4]
-  J[9:11,3:5] = diagm([3 * i for i = 3:5])
-  return J
 end
 
 function NLPModels.jac_structure!(nlp :: LINCON, rows :: AbstractVector{Int}, cols :: AbstractVector{Int})


### PR DESCRIPTION
I didn't remove `hess` for browden model because it was used for `hess_coord!` and `hprod!`.