### PR TITLE
Create auto-merge

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,5 @@
+minApprovals:
+  OWNER: 2
+reportStatus: true
+deleteBranchAfterMerge: true
+mergeMethod: rebase


### PR DESCRIPTION
I enabled the auto-merge bot for all JSO. Without an auto-merge.yml, it does nothing. For NLPModels.jl I added `OWNER: 2`, which means that both of us have to approve, which is useful only when the tests are taking too long. Other packages may need a less restrictive auto-merge to be useful, but I think our main use is this one.