### PR TITLE
Add new constructors for ADNLP and ADNLS models

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 
 [compat]
 Documenter = "~0.24"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Documenter, NLPModels
 makedocs(
   modules = [NLPModels],
   doctest = true,
-  linkcheck = true,
+  linkcheck = false,
   strict = true,
   format = Documenter.HTML(assets = ["assets/style.css"], prettyurls = get(ENV, "CI", nothing) == "true"),
   sitename = "NLPModels.jl",

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -60,7 +60,7 @@ using NLPModels
 f(x) = x[1]^2 + 4x[2]^2
 c(x) = [x[1]*x[2] - 1]
 x = [2.0; 2.0]
-nlp = ADNLPModel(f, x, c=c, lcon=[0.0])
+nlp = ADNLPModel(f, x, c, [0.0], [0.0])
 nlp_slack = SlackModel(nlp)
 nlp_slack.meta.lvar
 ```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -160,7 +160,7 @@ uvar = [0.5; 0.5]
 c(x) = [x[1] + x[2] - 2; x[1]^2 + x[2]^2]
 lcon = [0.0; -Inf]
 ucon = [Inf; 1.0]
-nlp = ADNLPModel(f, x0, c=c, lvar=lvar, uvar=uvar, lcon=lcon, ucon=ucon)
+nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon)
 
 println("cx = $(cons(nlp, nlp.meta.x0))")
 println("Jx = $(jac(nlp, nlp.meta.x0))")
@@ -313,8 +313,9 @@ Another way to define a nonlinear least squares is using `FeasibilityResidual` t
 consider the constraints of a general nonlinear problem as the residual of the NLS.
 ```@example nls
 nlp = ADNLPModel(x->0, # objective doesn't matter,
-                 ones(2), c=x->[x[1] + x[2] - 1; x[1] * x[2] - 2],
-                 lcon=zeros(2), ucon=zeros(2))
+                 ones(2),
+                 x->[x[1] + x[2] - 1; x[1] * x[2] - 2], # c(x)
+                 zeros(2), zeros(2)) # lcon, ucon
 nls = FeasibilityResidual(nlp)
 ```
 

--- a/test/nls_problems/lls.jl
+++ b/test/nls_problems/lls.jl
@@ -8,7 +8,7 @@ function lls_autodiff()
   lcon = [0.0]
   ucon = [Inf]
 
-  return ADNLSModel(F, x0, 3, c=c, lcon=lcon, ucon=ucon, name="lls_autodiff")
+  return ADNLSModel(F, x0, 3, c, lcon, ucon, name="lls_autodiff")
 end
 
 function lls_special()

--- a/test/nls_problems/nlshs20.jl
+++ b/test/nls_problems/nlshs20.jl
@@ -10,7 +10,7 @@ function nlshs20_autodiff()
   lcon = zeros(3)
   ucon = fill(Inf, 3)
 
-  return ADNLSModel(F, x0, 2, lvar=lvar, uvar=uvar, c=c, lcon=lcon, ucon=ucon, name="nlshs20_autodiff")
+  return ADNLSModel(F, x0, 2, lvar, uvar, c, lcon, ucon, name="nlshs20_autodiff")
 end
 
 mutable struct NLSHS20 <: AbstractNLSModel

--- a/test/nls_problems/nlslc.jl
+++ b/test/nls_problems/nlslc.jl
@@ -22,7 +22,7 @@ function nlslc_autodiff()
   lcon = [22.0; 1.0; -Inf; -11.0; -d;            -b; -Inf * ones(3)]
   ucon = [22.0; Inf; 16.0;   9.0; -d; Inf * ones(2);              c]
 
-  return ADNLSModel(F, x0, 15, c=con, lcon=lcon, ucon=ucon, name="nlslincon_autodiff")
+  return ADNLSModel(F, x0, 15, con, lcon, ucon, name="nlslincon_autodiff")
 end
 
 mutable struct NLSLC <: AbstractNLSModel

--- a/test/problems/hs10.jl
+++ b/test/problems/hs10.jl
@@ -9,7 +9,7 @@ function hs10_autodiff()
   lcon = [0.0]
   ucon = [Inf]
 
-  return ADNLPModel(f, x0, c=c, lcon=lcon, ucon=ucon, name="hs10_autodiff")
+  return ADNLPModel(f, x0, c, lcon, ucon, name="hs10_autodiff")
 end
 
 mutable struct HS10 <: AbstractNLPModel

--- a/test/problems/hs11.jl
+++ b/test/problems/hs11.jl
@@ -7,7 +7,7 @@ function hs11_autodiff()
   lcon = [-Inf]
   ucon = [0.0]
 
-  return ADNLPModel(f, x0, c=c, lcon=lcon, ucon=ucon, name="hs11_autodiff")
+  return ADNLPModel(f, x0, c, lcon, ucon, name="hs11_autodiff")
 
 end
 

--- a/test/problems/hs14.jl
+++ b/test/problems/hs14.jl
@@ -7,7 +7,7 @@ function hs14_autodiff()
   lcon = [0.0; 0.0]
   ucon = [0.0; Inf]
 
-  return ADNLPModel(f, x0, c=c, lcon=lcon, ucon=ucon, name="hs14_autodiff")
+  return ADNLPModel(f, x0, c, lcon, ucon, name="hs14_autodiff")
 end
 
 mutable struct HS14 <: AbstractNLPModel

--- a/test/problems/hs5.jl
+++ b/test/problems/hs5.jl
@@ -8,7 +8,7 @@ function hs5_autodiff()
   l = [-1.5; -3.0]
   u = [4.0; 3.0]
 
-  return ADNLPModel(f, x0, lvar=l, uvar=u, name="hs5_autodiff")
+  return ADNLPModel(f, x0, l, u, name="hs5_autodiff")
 end
 
 mutable struct HS5 <: AbstractNLPModel

--- a/test/problems/hs6.jl
+++ b/test/problems/hs6.jl
@@ -8,7 +8,7 @@ function hs6_autodiff()
   lcon = [0.0]
   ucon = [0.0]
 
-  return ADNLPModel(f, x0, c=c, lcon=lcon, ucon=ucon, name="hs6_autodiff")
+  return ADNLPModel(f, x0, c, lcon, ucon, name="hs6_autodiff")
 end
 
 mutable struct HS6 <: AbstractNLPModel

--- a/test/problems/lincon.jl
+++ b/test/problems/lincon.jl
@@ -20,7 +20,7 @@ function lincon_autodiff()
   lcon = [22.0; 1.0; -Inf; -11.0; -d;            -b; -Inf * ones(3)]
   ucon = [22.0; Inf; 16.0;   9.0; -d; Inf * ones(2);              c]
 
-  return ADNLPModel(f, x0, c=con, lcon=lcon, ucon=ucon, name="lincon_autodiff")
+  return ADNLPModel(f, x0, con, lcon, ucon, name="lincon_autodiff")
 end
 
 mutable struct LINCON <: AbstractNLPModel

--- a/test/problems/linsv.jl
+++ b/test/problems/linsv.jl
@@ -6,7 +6,7 @@ function linsv_autodiff()
   lcon = [3; 1]
   ucon = [Inf; Inf]
 
-  return ADNLPModel(f, x0, c=con, lcon=lcon, ucon=ucon, name="linsv_autodiff")
+  return ADNLPModel(f, x0, con, lcon, ucon, name="linsv_autodiff")
 end
 
 mutable struct LINSV <: AbstractNLPModel

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,11 +12,11 @@ for problem in nls_problems
 end
 
 @info("Testing printing of nlp.meta")
-print(ADNLPModel(x->0, zeros(10), lvar=[-ones(5); -Inf*ones(5)],
-                 uvar=[ones(3); Inf*ones(4); collect(2:4)],
+print(ADNLPModel(x->0, zeros(10), [-ones(5); -Inf*ones(5)],
+                 [ones(3); Inf*ones(4); collect(2:4)],
                  name="Unconstrained example").meta)
-print(ADNLPModel(x->0, zeros(10), c=x->[0.0;0.0;0.0], lcon=[0.0;0.0;-Inf],
-                 ucon=[Inf;0.0;0.0], name="Constrained example").meta)
+print(ADNLPModel(x->0, zeros(10), x->[0.0;0.0;0.0], [0.0;0.0;-Inf],
+                 [Inf;0.0;0.0], name="Constrained example").meta)
 
 # A problem with zero variables doesn't make sense.
 @test_throws(ErrorException, NLPModelMeta(0))

--- a/test/test_autodiff_model.jl
+++ b/test/test_autodiff_model.jl
@@ -14,7 +14,7 @@ function test_autodiff_model()
   nlp = ADNLPModel(f, x0)
 
   c(x) = [sum(x) - 1]
-  nlp = ADNLPModel(f, x0, c=c, lcon=[0], ucon=[0])
+  nlp = ADNLPModel(f, x0, c, [0], [0])
   @test obj(nlp, x0) == f(x0)
 
   x = range(-1, stop=1, length=100)
@@ -25,19 +25,26 @@ function test_autodiff_model()
   @test abs(obj(nlp, β) - norm(y .- β[1] - β[2] * x)^2 / 2) < 1e-12
   @test norm(grad(nlp, β)) < 1e-12
 
-  # Testing input
-  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0])
-  nlp = ADNLPModel(f, x0, c=c, ucon=[0.0])
-  nlp = ADNLPModel(f, x0, c=c, y0=[0.0])
-  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0])
-  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0], y0=[0.0])
-  nlp = ADNLPModel(f, x0, c=c, ucon=[0.0], y0=[0.0])
-  nlp = ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0], y0=[0.0])
-  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0; 0.0])
-  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0; 0.0], ucon=[0.0])
-  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0; 0.0], y0=[0.0])
-  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0; 0.0], ucon=[0.0], y0=[0.0])
-  @test_throws DimensionError ADNLPModel(f, x0, c=c, lcon=[0.0], ucon=[0.0], y0=[0.0; 0.0])
+  @testset "Constructors for ADNLPModel" begin
+    lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
+    badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
+    nlp = ADNLPModel(f, x0)
+    nlp = ADNLPModel(f, x0, lvar, uvar)
+    nlp = ADNLPModel(f, x0, c, lcon, ucon)
+    nlp = ADNLPModel(f, x0, c, lcon, ucon, y0=y0)
+    nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon)
+    nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0=y0)
+    @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar)
+    @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar)
+    @test_throws DimensionError ADNLPModel(f, x0, c, badlcon, ucon)
+    @test_throws DimensionError ADNLPModel(f, x0, c, lcon, baducon)
+    @test_throws DimensionError ADNLPModel(f, x0, c, lcon, ucon, y0=bady0)
+    @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar, c, lcon, ucon)
+    @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar, c, lcon, ucon)
+    @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, badlcon, ucon)
+    @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, lcon, baducon)
+    @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0=bady0)
+  end
 end
 
 test_autodiff_model()

--- a/test/test_autodiff_nls_model.jl
+++ b/test/test_autodiff_nls_model.jl
@@ -1,9 +1,34 @@
 function autodiff_nls_test()
   @testset "autodiff_nls_test" begin
     F(x) = [x[1] - 1; x[2] - x[1]^2]
-    nls = ADNLSModel(F, 2, 2)
+    nls = ADNLSModel(F, zeros(2), 2)
 
     @test isapprox(residual(nls, ones(2)), zeros(2), rtol=1e-8)
+  end
+
+  @testset "Constructors for ADNLSModel" begin
+    F(x) = [x[1] - 1; x[2] - x[1]^2; x[1] * x[2]]
+    x0 = ones(2)
+    c(x) = [sum(x) - 1]
+    lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
+    badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
+    nlp = ADNLSModel(F, x0, 3)
+    nlp = ADNLSModel(F, x0, 3, lvar, uvar)
+    nlp = ADNLSModel(F, x0, 3, c, lcon, ucon)
+    nlp = ADNLSModel(F, x0, 3, c, lcon, ucon, y0=y0)
+    nlp = ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon)
+    nlp = ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon, y0=y0)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, badlvar, uvar)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, baduvar)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, c, badlcon, ucon)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, c, lcon, baducon)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, c, lcon, ucon, y0=bady0)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, badlvar, uvar, c, lcon, ucon)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, baduvar, c, lcon, ucon)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, badlcon, ucon)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, baducon)
+    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon, y0=bady0)
+
   end
 end
 

--- a/test/test_feasibility_form_nls.jl
+++ b/test/test_feasibility_form_nls.jl
@@ -7,17 +7,17 @@ function test_nls_to_cons()
     for (F,n,ne) in [(F1,2,2), (F2,5,1), (F3,2,3)],
         (c,m) in [(x->zeros(0),0), (c1,2)]
       x0 = [-(1.0)^i for i = 1:n]
-      nls = ADNLSModel(F, x0, ne, c=c, lcon=zeros(m), ucon=zeros(m))
+      nls = ADNLSModel(F, x0, ne, c, zeros(m), zeros(m))
 
       nlpcon = FeasibilityFormNLS(nls)
       adnlp = ADNLPModel(x->sum(x[n+1:end].^2) / 2, [x0; zeros(ne)],
-                        c=x->[F(x[1:n]) - x[n+1:end]; c(x[1:n])],
-                        lcon=zeros(ne+m), ucon=zeros(ne+m))
+                        x->[F(x[1:n]) - x[n+1:end]; c(x[1:n])],
+                        zeros(ne+m), zeros(ne+m))
       consistent_functions([nlpcon; adnlp])
 
       adnls = ADNLSModel(x->x[n+1:end], [x0; zeros(ne)], ne,
-                        c=x->[F(x[1:n]) - x[n+1:end]; c(x[1:n])],
-                        lcon=zeros(ne+m), ucon=zeros(ne+m))
+                        x->[F(x[1:n]) - x[n+1:end]; c(x[1:n])],
+                        zeros(ne+m), zeros(ne+m))
       consistent_functions([nlpcon; adnls])
       consistent_nls_functions([nlpcon; adnls])
     end
@@ -48,10 +48,10 @@ function test_nls_to_cons()
   @testset "Test FeasibilityFormNLS of a FeasibilityResidual" begin
     c(x) = [x[1]^2 + x[2]^2 - 5; x[1] * x[2] - 2; x[1] - 1; x[2] - 1]
     x0 = [0.5; 1.5]
-    nlp = ADNLPModel(x->0, x0, c=c, lcon=zeros(4), ucon=zeros(4))
+    nlp = ADNLPModel(x->0, x0, c, zeros(4), zeros(4))
     ffnls = FeasibilityFormNLS(FeasibilityResidual(nlp))
     nlp2 = ADNLSModel(x->x[3:6], [x0; zeros(4)], 4,
-                      c=x->c(x[1:2]) - x[3:6], lcon=zeros(4), ucon=zeros(4))
+                      x->c(x[1:2]) - x[3:6], zeros(4), zeros(4))
     consistent_functions([ffnls; nlp2])
     consistent_nls_functions([ffnls; nlp2])
 

--- a/test/test_feasibility_nls_model.jl
+++ b/test/test_feasibility_nls_model.jl
@@ -1,14 +1,12 @@
 function feasibility_nls_test()
   @testset "feasibility_nls_test" begin
-    nlp = ADNLPModel(x->0, zeros(2), c=x->[x[1] - 1; x[2] - x[1]^2],
-                     lcon=zeros(2), ucon=zeros(2))
+    nlp = ADNLPModel(x->0, zeros(2), x->[x[1] - 1; x[2] - x[1]^2], zeros(2), zeros(2))
     nls = FeasibilityResidual(nlp)
 
     @test isapprox(residual(nls, ones(2)), zeros(2), rtol=1e-8)
 
-    nlp = ADNLPModel(x->0, zeros(2), c=x->[x[1] - 1; x[2] - x[1]^2],
-                     lvar=[-0.3; -0.5], uvar=[1.2; 3.4],
-                     lcon=-ones(2), ucon=2*ones(2))
+    nlp = ADNLPModel(x->0, zeros(2), [-0.3; -0.5], [1.2; 3.4],
+                     x->[x[1] - 1; x[2] - x[1]^2], -ones(2), 2*ones(2))
     nls = FeasibilityResidual(nlp)
 
     @test nls.meta.nvar == 4

--- a/test/test_memory_of_coord.jl
+++ b/test/test_memory_of_coord.jl
@@ -36,7 +36,7 @@ function test_memory_of_coord()
       nlp = eval(p)()
       test_memory_of_coord_of_nlp(nlp)
     end
-    nlp = ADNLPModel(x -> dot(x, x), rand(2), c=x->[x[1] * x[2]], lcon=zeros(1), ucon=zeros(1))
+    nlp = ADNLPModel(x -> dot(x, x), rand(2), x->[x[1] * x[2]], zeros(1), zeros(1))
     test_memory_of_coord_of_nlp(nlp)
   end
 end

--- a/test/test_slack_model.jl
+++ b/test/test_slack_model.jl
@@ -114,7 +114,7 @@
 end
 
 @testset "Test that type is maintained (#217)" begin
-  nlp = ADNLPModel(x -> dot(x, x), ones(Float16, 2), c=x->sum(x), lcon=[-1.0], ucon=[1.0])
+  nlp = ADNLPModel(x -> dot(x, x), ones(Float16, 2), x->sum(x), [-1.0], [1.0])
   snlp = SlackModel(nlp)
   @test eltype(snlp.meta.x0) == Float16
 end

--- a/test/test_tools.jl
+++ b/test/test_tools.jl
@@ -6,8 +6,7 @@ nlp = ADNLPModel(x->dot(x,x), zeros(2))
 @test !equality_constrained(nlp)
 @test !inequality_constrained(nlp)
 
-nlp = ADNLPModel(x->dot(x,x), zeros(2),
-                 lvar=zeros(2))
+nlp = ADNLPModel(x->dot(x,x), zeros(2), zeros(2), zeros(2))
 @test has_bounds(nlp)
 @test bound_constrained(nlp)
 @test !unconstrained(nlp)
@@ -15,8 +14,7 @@ nlp = ADNLPModel(x->dot(x,x), zeros(2),
 @test !equality_constrained(nlp)
 @test !inequality_constrained(nlp)
 
-nlp = ADNLPModel(x->dot(x,x), zeros(2),
-                 c=x->[prod(x)-1], lcon=[0.0], ucon=[0.0])
+nlp = ADNLPModel(x->dot(x,x), zeros(2), x->[prod(x)-1], [0.0], [0.0])
 @test !has_bounds(nlp)
 @test !bound_constrained(nlp)
 @test !unconstrained(nlp)
@@ -24,8 +22,7 @@ nlp = ADNLPModel(x->dot(x,x), zeros(2),
 @test equality_constrained(nlp)
 @test !inequality_constrained(nlp)
 
-nlp = ADNLPModel(x->dot(x,x), zeros(2),
-                 c=x->[prod(x)-1], lcon=[0.0], ucon=[1.0])
+nlp = ADNLPModel(x->dot(x,x), zeros(2), x->[prod(x)-1], [0.0], [1.0])
 @test !has_bounds(nlp)
 @test !bound_constrained(nlp)
 @test !unconstrained(nlp)
@@ -33,9 +30,7 @@ nlp = ADNLPModel(x->dot(x,x), zeros(2),
 @test !equality_constrained(nlp)
 @test inequality_constrained(nlp)
 
-nlp = ADNLPModel(x->dot(x,x), zeros(2),
-                 c=x->[prod(x)-1; sum(x)-1],
-                 lcon=zeros(2), ucon=[0.0; Inf])
+nlp = ADNLPModel(x->dot(x,x), zeros(2), x->[prod(x)-1; sum(x)-1], zeros(2), [0.0; Inf])
 @test !has_bounds(nlp)
 @test !bound_constrained(nlp)
 @test !unconstrained(nlp)
@@ -43,9 +38,7 @@ nlp = ADNLPModel(x->dot(x,x), zeros(2),
 @test !equality_constrained(nlp)
 @test !inequality_constrained(nlp)
 
-nlp = ADNLPModel(x->dot(x,x), zeros(2),
-                 c=x->[sum(x)-1], lcon=zeros(1), ucon=zeros(1),
-                 lin=[1])
+nlp = ADNLPModel(x->dot(x,x), zeros(2), x->[sum(x)-1], zeros(1), zeros(1), lin=[1])
 @test !has_bounds(nlp)
 @test !bound_constrained(nlp)
 @test !unconstrained(nlp)
@@ -53,9 +46,7 @@ nlp = ADNLPModel(x->dot(x,x), zeros(2),
 @test equality_constrained(nlp)
 @test !inequality_constrained(nlp)
 
-nlp = ADNLPModel(x->dot(x,x), zeros(2), lvar=zeros(2), uvar=ones(2),
-                 c=x->[sum(x)-1], lcon=zeros(1), ucon=zeros(1),
-                 lin=[1])
+nlp = ADNLPModel(x->dot(x,x), zeros(2), zeros(2), ones(2), x->[sum(x)-1], zeros(1), zeros(1), lin=[1])
 @test has_bounds(nlp)
 @test !bound_constrained(nlp)
 @test !unconstrained(nlp)

--- a/test/test_view_subarray.jl
+++ b/test/test_view_subarray.jl
@@ -188,15 +188,13 @@ end
 function test_view_subarrays()
   @testset "Test view subarrays for many models" begin
     c(x) = [dot(x, x) - 4.0; sum(x) - 1.0; x[1] * x[2] * x[3]]
-    adnlp = ADNLPModel(x -> sum(x.^4), ones(5), lvar=-ones(5), uvar=fill(Inf, 5),
-                       c=c, lcon=-ones(3), ucon=ones(3))
+    adnlp = ADNLPModel(x -> sum(x.^4), ones(5), -ones(5), fill(Inf, 5), c, -ones(3), ones(3))
     snlp = SlackModel(adnlp)
     adnls = ADNLSModel(x -> [sum(x) - 1; sum(x.^2) - 2; sum(x.^3) - 3], ones(5), 3,
-                       lvar=-ones(5), uvar=fill(Inf, 5),
-                       c=c, lcon=-ones(3), ucon=ones(3))
+                       -ones(5), fill(Inf, 5), c, -ones(3), ones(3))
     snls = SlackNLSModel(adnls)
 
-    fnls = FeasibilityResidual(ADNLPModel(x->0, zeros(5), c=c, lcon=zeros(3), ucon=zeros(3)))
+    fnls = FeasibilityResidual(ADNLPModel(x->0, zeros(5), c, zeros(3), zeros(3)))
 
     for nlp in [adnlp, snlp, adnls, snls, fnls]
       test_view_subarray_nlp(nlp)


### PR DESCRIPTION
The only problem with this is that `ADNLPModel(f, x0, c=c, lcon=lcon, ucon=ucon)` doesn't work out of the box now. It needs `ncon=ncon` too.