### PR TITLE
Add exclude to consistent_nlps and defaults to ghjvprod

### DIFF
--- a/test/consistency.jl
+++ b/test/consistency.jl
@@ -397,10 +397,10 @@ function consistent_functions(nlps; rtol=1.0e-8, exclude=[])
 
 end
 
-function consistent_nlps(nlps; rtol=1.0e-8)
+function consistent_nlps(nlps; exclude=[ghjvprod], rtol=1.0e-8)
   consistent_counters(nlps)
   consistent_meta(nlps, rtol=rtol)
-  consistent_functions(nlps, rtol=rtol)
+  consistent_functions(nlps, rtol=rtol, exclude=exclude)
   consistent_counters(nlps)
   for nlp in nlps
     reset!(nlp)
@@ -416,13 +416,13 @@ function consistent_nlps(nlps; rtol=1.0e-8)
   # Test Quasi-Newton models
   qnmodels = [[LBFGSModel(nlp) for nlp in nlps];
               [LSR1Model(nlp) for nlp in nlps]]
-  consistent_functions([nlps; qnmodels], exclude=[hess, hess_coord, hprod, ghjvprod])
+  consistent_functions([nlps; qnmodels], exclude=[hess, hess_coord, hprod, ghjvprod] ∪ exclude)
   consistent_counters([nlps; qnmodels])
 
   # If there are inequalities, test the SlackModels of each of these models
   if nlps[1].meta.ncon == length(nlps[1].meta.jfix)
     slack_nlps = [SlackModel(nlp) for nlp in nlps]
-    consistent_functions(slack_nlps)
+    consistent_functions(slack_nlps, exclude=exclude)
     consistent_counters(slack_nlps)
   end
 end

--- a/test/nls_consistency.jl
+++ b/test/nls_consistency.jl
@@ -163,7 +163,7 @@ function consistent_nls_functions(nlss; rtol=1.0e-8, exclude=[])
   end
 end
 
-function consistent_nlss(nlss; exclude=[hess, hess_coord])
+function consistent_nlss(nlss; exclude=[hess, hess_coord, ghjvprod])
   consistent_nls_counters(nlss)
   consistent_counters(nlss)
   consistent_nls_functions(nlss, exclude=exclude)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,7 +89,7 @@ for problem in problems
     show(nlp)
   end
 
-  consistent_nlps(nlps)
+  consistent_nlps(nlps, exclude=[])
   @info "  Consistency checks ✓"
 
   for nlp in nlps ∪ SlackModel.(nlps)


### PR DESCRIPTION
~Waiting for #324, do not merge.~ Ready.

ghjvprod breaks a few other packages, so it is initially excluded from the API consistency tests.