### PR TITLE
Update default arguments for NLPModelMeta

### DIFF
--- a/src/nlp/meta.jl
+++ b/src/nlp/meta.jl
@@ -118,9 +118,9 @@ struct NLPModelMeta{T, S} <: AbstractNLPModelMeta{T, S}
 
   function NLPModelMeta{T, S}(
     nvar::Int;
-    x0::S = zeros(T, nvar),
-    lvar::S = T(-Inf) * ones(T, nvar),
-    uvar::S = T(Inf) * ones(T, nvar),
+    x0::S = fill!(S(undef, nvar), zero(T)),
+    lvar::S = fill!(S(undef, nvar), T(-Inf)),
+    uvar::S = fill!(S(undef, nvar), T(Inf)),
     nbv = 0,
     niv = 0,
     nlvb = nvar,
@@ -131,9 +131,9 @@ struct NLPModelMeta{T, S} <: AbstractNLPModelMeta{T, S}
     nlvoi = 0,
     nwv = 0,
     ncon = 0,
-    y0::S = zeros(T, ncon),
-    lcon::S = T(-Inf) * ones(T, ncon),
-    ucon::S = T(Inf) * ones(T, ncon),
+    y0::S = fill!(S(undef, ncon), zero(T)),
+    lcon::S = fill!(S(undef, ncon), T(-Inf)),
+    ucon::S = fill!(S(undef, ncon), T(Inf)),
     nnzo = nvar,
     nnzj = nvar * ncon,
     nnzh = nvar * (nvar + 1) / 2,

--- a/src/nls/meta.jl
+++ b/src/nls/meta.jl
@@ -32,7 +32,7 @@ struct NLSMeta{T, S}
   function NLSMeta{T, S}(
     nequ::Int,
     nvar::Int;
-    x0::S = zeros(T, nvar),
+    x0::S = fill!(S(undef, nvar), zero(T)),
     nnzj = nequ * nvar,
     nnzh = div(nvar * (nvar + 1), 2),
     nln = 1:nequ,


### PR DESCRIPTION
With this PR and after updating the compatibilities of NLPModelsModifiers, SolverCore and QuadraticModels, I am able to create a QuadraticModel with ` CuArray{Float64, 1}` vectors.