### PR TITLE
Remove matrix-product with the structure only

### DIFF
--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -201,21 +201,6 @@ function jprod!(
 end
 
 """
-    Jv = jprod!(nlp, x, rows, cols, v, Jv)
-
-Evaluate ``J(x)v``, the Jacobian-vector product at `x` in place.
-`(rows, cols)` should be the Jacobian structure in triplet format.
-"""
-jprod!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  ::AbstractVector{<:Integer},
-  ::AbstractVector{<:Integer},
-  v::AbstractVector,
-  Jv::AbstractVector,
-) = jprod!(nlp, x, v, Jv)
-
-"""
     Jtv = jtprod(nlp, x, v, Jtv)
 
 Evaluate ``J(x)^Tv``, the transposed-Jacobian-vector product at `x`.
@@ -254,21 +239,6 @@ function jtprod!(
   increment!(nlp, :neval_jtprod)
   coo_prod!(cols, rows, vals, v, Jtv)
 end
-
-"""
-    Jtv = jtprod!(nlp, x, rows, cols, v, Jtv)
-
-Evaluate ``J(x)^Tv``, the transposed-Jacobian-vector product at `x` in place.
-`(rows, cols)` should be the Jacobian structure in triplet format.
-"""
-jtprod!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  ::AbstractVector{<:Integer},
-  ::AbstractVector{<:Integer},
-  v::AbstractVector,
-  Jtv::AbstractVector,
-) = jtprod!(nlp, x, v, Jtv)
 
 """
     J = jac_op(nlp, x)
@@ -664,24 +634,6 @@ function hprod!(
 end
 
 """
-    Hv = hprod!(nlp, x, rows, cols, v, Hv; obj_weight=1.0)
-
-Evaluate the product of the objective Hessian at `x` with the vector `v` in
-place, where the objective Hessian is
-$(OBJECTIVE_HESSIAN).
-`(rows, cols)` should be the Hessian structure in triplet format.
-"""
-hprod!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  ::AbstractVector{<:Integer},
-  ::AbstractVector{<:Integer},
-  v::AbstractVector,
-  Hv::AbstractVector;
-  obj_weight::Real = 1.0,
-) = hprod!(nlp, x, v, Hv, obj_weight = obj_weight)
-
-"""
     Hv = hprod!(nlp, x, y, v, Hv; obj_weight=1.0)
 
 Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
@@ -689,25 +641,6 @@ place, with objective function scaled by `obj_weight`, where the Lagrangian Hess
 $(LAGRANGIAN_HESSIAN).
 """
 function hprod! end
-
-"""
-    Hv = hprod!(nlp, x, y, rows, cols, v, Hv; obj_weight=1.0)
-
-Evaluate the product of the Lagrangian Hessian at `(x,y)` with the vector `v` in
-place, where the Lagrangian Hessian is
-$(LAGRANGIAN_HESSIAN).
-`(rows, cols)` should be the Hessian structure in triplet format.
-"""
-hprod!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  y::AbstractVector,
-  ::AbstractVector{<:Integer},
-  ::AbstractVector{<:Integer},
-  v::AbstractVector,
-  Hv::AbstractVector;
-  obj_weight::Real = one(eltype(x)),
-) = hprod!(nlp, x, y, v, Hv, obj_weight = obj_weight)
 
 """
     H = hess_op(nlp, x; obj_weight=1.0)

--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -339,30 +339,6 @@ function jac_op!(
 end
 
 """
-    J = jac_op!(nlp, x, rows, cols, Jv, Jtv)
-
-Return the Jacobian at `x` as a linear operator.
-The resulting object may be used as if it were a matrix, e.g., `J * v` or
-`J' * v`. `(rows, cols)` should be the sparsity structure of the Jacobian.
-The values `Jv` and `Jtv` are used as preallocated storage for the operations.
-"""
-function jac_op!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  rows::AbstractVector{<:Integer},
-  cols::AbstractVector{<:Integer},
-  Jv::AbstractVector,
-  Jtv::AbstractVector,
-)
-  @lencheck nlp.meta.nvar x Jtv
-  @lencheck nlp.meta.nnzj rows cols
-  @lencheck nlp.meta.ncon Jv
-  vals = jac_coord(nlp, x)
-  decrement!(nlp, :neval_jac)
-  return jac_op!(nlp, rows, cols, vals, Jv, Jtv)
-end
-
-"""
     vals = jth_hess_coord(nlp, x, j)
 
 Evaluate the Hessian of j-th constraint at `x` in sparse coordinate format.
@@ -741,31 +717,6 @@ function hess_op!(
 end
 
 """
-    H = hess_op!(nlp, x, rows, cols, Hv; obj_weight=1.0)
-
-Return the objective Hessian at `x` with objective function scaled by
-`obj_weight` as a linear operator, and storing the result on `Hv`. The resulting
-object may be used as if it were a matrix, e.g., `w = H * v`.
-`(rows, cols)` should be the sparsity structure of the Hessian.
-The vector `Hv` is used as preallocated storage for the operation.  The linear operator H
-represents
-$(OBJECTIVE_HESSIAN).
-"""
-function hess_op!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  rows::AbstractVector{<:Integer},
-  cols::AbstractVector{<:Integer},
-  Hv::AbstractVector;
-  obj_weight::Real = one(eltype(x)),
-)
-  @lencheck nlp.meta.nvar x Hv
-  @lencheck nlp.meta.nnzh rows cols
-  vals = hess_coord(nlp, x, obj_weight = obj_weight)
-  return hess_op!(nlp, rows, cols, vals, Hv)
-end
-
-"""
     H = hess_op!(nlp, x, y, Hv; obj_weight=1.0)
 
 Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
@@ -794,34 +745,6 @@ function hess_op!(
     return res
   end
   return LinearOperator{eltype(x)}(nlp.meta.nvar, nlp.meta.nvar, true, true, prod!, prod!, prod!)
-end
-
-"""
-    H = hess_op!(nlp, x, y, rows, cols, Hv; obj_weight=1.0)
-
-Return the Lagrangian Hessian at `(x,y)` with objective function scaled by
-`obj_weight` as a linear operator, and storing the result on `Hv`. The resulting
-object may be used as if it were a matrix, e.g., `w = H * v`.
-`(rows, cols)` should be the sparsity structure of the Hessian.
-The vector `Hv` is used as preallocated storage for the operation.  The linear operator H
-represents
-$(OBJECTIVE_HESSIAN).
-"""
-function hess_op!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  y::AbstractVector,
-  rows::AbstractVector{<:Integer},
-  cols::AbstractVector{<:Integer},
-  Hv::AbstractVector;
-  obj_weight::Real = one(eltype(x)),
-)
-  @lencheck nlp.meta.nvar x Hv
-  @lencheck nlp.meta.ncon y
-  @lencheck nlp.meta.nnzh rows cols
-  vals = hess_coord(nlp, x, y, obj_weight = obj_weight)
-  decrement!(nlp, :neval_hess)
-  return hess_op!(nlp, rows, cols, vals, Hv)
 end
 
 function varscale end

--- a/src/nls/api.jl
+++ b/src/nls/api.jl
@@ -261,29 +261,6 @@ function jac_op_residual!(
 end
 
 """
-    Jx = jac_op_residual!(nls, x, rows, cols, Jv, Jtv)
-
-Computes ``J(x)``, the Jacobian of the residual at x, in linear operator form. The
-vectors `Jv` and `Jtv` are used as preallocated storage for the operations.
-The structure of the Jacobian should be given by `(rows, cols)`.
-"""
-function jac_op_residual!(
-  nls::AbstractNLSModel,
-  x::AbstractVector,
-  rows::AbstractVector{<:Integer},
-  cols::AbstractVector{<:Integer},
-  Jv::AbstractVector,
-  Jtv::AbstractVector,
-)
-  @lencheck nls.meta.nvar x Jtv
-  @lencheck nls.nls_meta.nnzj rows cols
-  @lencheck nls.nls_meta.nequ Jv
-  vals = jac_coord_residual(nls, x)
-  decrement!(nls, :neval_jac_residual)
-  return jac_op_residual!(nls, rows, cols, vals, Jv, Jtv)
-end
-
-"""
     H = hess_residual(nls, x, v)
 
 Computes the linear combination of the Hessians of the residuals at `x` with coefficients

--- a/src/nls/api.jl
+++ b/src/nls/api.jl
@@ -116,26 +116,6 @@ function jprod_residual!(
 end
 
 """
-    Jv = jprod_residual!(nls, x, rows, cols, v, Jv)
-
-Computes the product of the Jacobian of the residual at x and a vector, i.e.,  ``J(x)v``, storing it in `Jv`.
-The structure of the Jacobian is given by `(rows, cols)`.
-"""
-function jprod_residual!(
-  nls::AbstractNLSModel,
-  x::AbstractVector,
-  rows::AbstractVector{<:Integer},
-  cols::AbstractVector{<:Integer},
-  v::AbstractVector,
-  Jv::AbstractVector,
-)
-  @lencheck nls.meta.nvar x v
-  @lencheck nls.nls_meta.nnzj rows cols
-  @lencheck nls.nls_meta.nequ Jv
-  jprod_residual!(nls, x, v, Jv)
-end
-
-"""
     Jtv = jtprod_residual(nls, x, v)
 
 Computes the product of the transpose of the Jacobian of the residual at x and a vector, i.e.,  ``J(x)^Tv``.
@@ -177,26 +157,6 @@ function jtprod_residual!(
   @lencheck nls.meta.nvar Jtv
   increment!(nls, :neval_jtprod_residual)
   coo_prod!(cols, rows, vals, v, Jtv)
-end
-
-"""
-    Jtv = jtprod_residual!(nls, x, rows, cols, v, Jtv)
-
-Computes the product of the transpose Jacobian of the residual at x and a vector, i.e.,  ``J(x)^Tv``, storing it in `Jv`.
-The structure of the Jacobian is given by `(rows, cols)`.
-"""
-function jtprod_residual!(
-  nls::AbstractNLSModel,
-  x::AbstractVector,
-  rows::AbstractVector{<:Integer},
-  cols::AbstractVector{<:Integer},
-  v::AbstractVector,
-  Jtv::AbstractVector,
-)
-  @lencheck nls.meta.nvar x Jtv
-  @lencheck nls.nls_meta.nnzj rows cols
-  @lencheck nls.nls_meta.nequ v
-  jtprod_residual!(nls, x, v, Jtv)
 end
 
 """

--- a/test/nlp/api.jl
+++ b/test/nlp/api.jl
@@ -45,9 +45,7 @@
   @test fx ≈ f(x)
   @test gx ≈ ∇f(x)
   @test jprod!(nlp, jac_structure(nlp)..., jac_coord(nlp, x), v, Jv) ≈ J(x) * v
-  @test jprod!(nlp, x, jac_structure(nlp)..., v, Jv) ≈ J(x) * v
   @test jtprod!(nlp, jac_structure(nlp)..., jac_coord(nlp, x), w, Jtw) ≈ J(x)' * w
-  @test jtprod!(nlp, x, jac_structure(nlp)..., w, Jtw) ≈ J(x)' * w
   Jop = jac_op!(nlp, x, Jv, Jtw)
   @test Jop * v ≈ J(x) * v
   @test Jop' * w ≈ J(x)' * w
@@ -80,8 +78,6 @@
   @test ghjvprod(nlp, x, gx, v) ≈ ghjv
   @test hess_coord!(nlp, x, Hvals) == hess_coord!(nlp, x, y * 0, Hvals)
   @test hprod!(nlp, hess_structure(nlp)..., hess_coord(nlp, x), v, Hv) ≈ H(x) * v
-  @test hprod!(nlp, x, hess_structure(nlp)..., v, Hv) ≈ H(x) * v
-  @test hprod!(nlp, x, y, hess_structure(nlp)..., v, Hv) ≈ H(x, y) * v
   Hop = hess_op(nlp, x)
   @test Hop * v ≈ H(x) * v
   Hop = hess_op!(nlp, x, Hv)

--- a/test/nlp/api.jl
+++ b/test/nlp/api.jl
@@ -60,9 +60,6 @@
   @test mul!(w, Jop, v, 1.0, -1.0) ≈ res
   res = J(x)' * w - v
   @test mul!(v, Jop', w, 1.0, -1.0) ≈ res
-  Jop = jac_op!(nlp, x, jac_structure(nlp)..., Jv, Jtw)
-  @test Jop * v ≈ J(x) * v
-  @test Jop' * w ≈ J(x)' * w
   for j = 1:(nlp.meta.ncon)
     eⱼ = [i == j ? 1.0 : 0.0 for i = 1:m]
     @test jth_hess(nlp, x, j) == H(x, eⱼ) - H(x)
@@ -89,8 +86,6 @@
   @test Hop * v ≈ H(x) * v
   res = H(x) * v - z
   @test mul!(z, Hop, v, 1.0, -1.0) ≈ res
-  Hop = hess_op!(nlp, x, hess_structure(nlp)..., Hv)
-  @test Hop * v ≈ H(x) * v
   Hop = hess_op(nlp, x, y)
   @test Hop * v ≈ H(x, y) * v
   Hop = hess_op!(nlp, x, y, Hv)
@@ -98,8 +93,6 @@
   res = H(x, y) * v - z
   @test mul!(z, Hop, v, 1.0, -1.0) ≈ res
   Hop = hess_op!(nlp, hess_structure(nlp)..., hess_coord(nlp, x, y), Hv)
-  @test Hop * v ≈ H(x, y) * v
-  Hop = hess_op!(nlp, x, y, hess_structure(nlp)..., Hv)
   @test Hop * v ≈ H(x, y) * v
 end
 

--- a/test/nls/api.jl
+++ b/test/nls/api.jl
@@ -41,9 +41,6 @@
   @test mul!(w, Jop, v, 1.0, -1.0) ≈ res
   res = JF(x)' * w - v
   @test mul!(v, Jop', w, 1.0, -1.0) ≈ res
-  Jop = jac_op_residual!(nls, x, jac_structure_residual(nls)..., Jv, Jtw)
-  @test Jop * v ≈ JF(x) * v
-  @test Jop' * w ≈ JF(x)' * w
   I, J, V = findnz(sparse(HF(x, w)))
   @test hess_structure_residual(nls) == (I, J)
   @test hess_coord_residual(nls, x, w) ≈ V
@@ -116,9 +113,6 @@ end
   Jop = jac_op!(nls, jac_structure(nls)..., jac_coord(nls, x), Jv, Jtw)
   @test Jop * v ≈ J(x) * v
   @test Jop' * w ≈ J(x)' * w
-  Jop = jac_op!(nls, x, jac_structure(nls)..., Jv, Jtw)
-  @test Jop * v ≈ J(x) * v
-  @test Jop' * w ≈ J(x)' * w
   ghjv = zeros(m)
   for j = 1:m
     eⱼ = [i == j ? 1.0 : 0.0 for i = 1:m]
@@ -134,15 +128,11 @@ end
   @test Hop * v ≈ H(x) * v
   Hop = hess_op!(nls, hess_structure(nls)..., hess_coord(nls, x), Hv)
   @test Hop * v ≈ H(x) * v
-  Hop = hess_op!(nls, x, hess_structure(nls)..., Hv)
-  @test Hop * v ≈ H(x) * v
   Hop = hess_op(nls, x, y)
   @test Hop * v ≈ H(x, y) * v
   Hop = hess_op!(nls, x, y, Hv)
   @test Hop * v ≈ H(x, y) * v
   Hop = hess_op!(nls, hess_structure(nls)..., hess_coord(nls, x, y), Hv)
-  @test Hop * v ≈ H(x, y) * v
-  Hop = hess_op!(nls, x, y, hess_structure(nls)..., Hv)
   @test Hop * v ≈ H(x, y) * v
 end
 

--- a/test/nls/api.jl
+++ b/test/nls/api.jl
@@ -24,8 +24,6 @@
         JF(x) * v
   @test jtprod_residual!(nls, jac_structure_residual(nls)..., jac_coord_residual(nls, x), w, Jtw) ≈
         JF(x)' * w
-  @test jprod_residual!(nls, x, jac_structure_residual(nls)..., v, Jv) ≈ JF(x) * v
-  @test jtprod_residual!(nls, x, jac_structure_residual(nls)..., w, Jtw) ≈ JF(x)' * w
   Jop = jac_op_residual(nls, x)
   @test Jop * v ≈ JF(x) * v
   @test Jop' * w ≈ JF(x)' * w
@@ -111,9 +109,7 @@ end
   @test fx ≈ f(x)
   @test gx ≈ ∇f(x)
   @test jprod!(nls, jac_structure(nls)..., jac_coord(nls, x), v, Jv) ≈ J(x) * v
-  @test jprod!(nls, x, jac_structure(nls)..., v, Jv) ≈ J(x) * v
   @test jtprod!(nls, jac_structure(nls)..., jac_coord(nls, x), w, Jtw) ≈ J(x)' * w
-  @test jtprod!(nls, x, jac_structure(nls)..., w, Jtw) ≈ J(x)' * w
   Jop = jac_op!(nls, x, Jv, Jtw)
   @test Jop * v ≈ J(x) * v
   @test Jop' * w ≈ J(x)' * w
@@ -132,8 +128,6 @@ end
   @test ghjvprod(nls, x, gx, v) ≈ ghjv
   @test hess_coord!(nls, x, Hvals) == hess_coord!(nls, x, y * 0, Hvals)
   @test hprod!(nls, hess_structure(nls)..., hess_coord(nls, x), v, Hv) ≈ H(x) * v
-  @test hprod!(nls, x, hess_structure(nls)..., v, Hv) ≈ H(x) * v
-  @test hprod!(nls, x, y, hess_structure(nls)..., v, Hv) ≈ H(x, y) * v
   Hop = hess_op(nls, x)
   @test Hop * v ≈ H(x) * v
   Hop = hess_op!(nls, x, Hv)


### PR DESCRIPTION
I let:
```
jac_op!(nlp, x, rows, cols, Jv, Jtv)
hess_op!(nlp, x, rows, cols, Hv; obj_weight=1.0)
hess_op!(nlp, x, y, rows, cols, Hv; obj_weight=1.0)
```
and
```
jac_op_residual!(nls, x, rows, cols, Jv, Jtv)
```
in case initializing LinearOperators benefit from the structure.