### PR TITLE
Version 0.18.0 [Merge after #387]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLPModels"
 uuid = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
-version = "0.17.2"
+version = "0.18.0"
 
 [deps]
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"


### PR DESCRIPTION
#381 was breaking as it changes the way we select linear constraints.
Moreover, this release is the first step to set up the linear API.