### PR TITLE
inline increment! to avoid allocations

### DIFF
--- a/src/nlp/counters.jl
+++ b/src/nlp/counters.jl
@@ -48,7 +48,7 @@ end
 
 Increment counter `s` of problem `nlp`.
 """
-function increment!(nlp::AbstractNLPModel, s::Symbol)
+@inline function increment!(nlp::AbstractNLPModel, s::Symbol)
   setproperty!(nlp.counters, s, getproperty(nlp.counters, s) + 1)
 end
 


### PR DESCRIPTION
I found while benchmarking that `increment!()` allocates 2 bytes each time. It seems inlining solves the issue.