### PR TITLE
Fix linear API 2

### DIFF
--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -185,13 +185,13 @@ function jac_structure!(
   lin_ind = 1:(nlp.meta.lin_nnzj)
   nlp.meta.nlin > 0 && jac_lin_structure!(nlp, view(rows, lin_ind), view(cols, lin_ind))
   for i in lin_ind
-    rows[i] += count(<(nlp.meta.lin[rows[i]]), nlp.meta.nln)
+    rows[i] += count(x < nlp.meta.lin[rows[i]] for x in nlp.meta.nln)
   end
   if nlp.meta.nnln > 0
     nln_ind = (nlp.meta.lin_nnzj + 1):(nlp.meta.lin_nnzj + nlp.meta.nln_nnzj)
     jac_nln_structure!(nlp, view(rows, nln_ind), view(cols, nln_ind))
     for i in nln_ind
-      rows[i] += count(<(nlp.meta.nln[rows[i]]), nlp.meta.lin)
+      rows[i] += count(x < nlp.meta.nln[rows[i]] for x in nlp.meta.lin)
     end
   end
   return rows, cols

--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -187,7 +187,9 @@ function jac_structure!(
   if nlp.meta.nnln > 0
     nln_ind = (nlp.meta.lin_nnzj + 1):(nlp.meta.lin_nnzj + nlp.meta.nln_nnzj)
     jac_nln_structure!(nlp, view(rows, nln_ind), view(cols, nln_ind))
-    view(rows, nln_ind) .+= nlp.meta.nlin
+    for i in nln_ind, j in nlp.meta.lin
+      rows[i] += (j <= i)
+    end
   end
   return rows, cols
 end

--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -184,11 +184,22 @@ function jac_structure!(
   @lencheck nlp.meta.nnzj rows cols
   lin_ind = 1:(nlp.meta.lin_nnzj)
   nlp.meta.nlin > 0 && jac_lin_structure!(nlp, view(rows, lin_ind), view(cols, lin_ind))
+  for i in lin_ind
+    k = 0
+    for j in nlp.meta.nln
+      k += (j < nlp.meta.lin[rows[i]])
+    end
+    rows[i] += k
+  end
   if nlp.meta.nnln > 0
     nln_ind = (nlp.meta.lin_nnzj + 1):(nlp.meta.lin_nnzj + nlp.meta.nln_nnzj)
     jac_nln_structure!(nlp, view(rows, nln_ind), view(cols, nln_ind))
-    for i in nln_ind, j in nlp.meta.lin
-      rows[i] += (j <= i)
+    for i in nln_ind
+      k = 0
+      for j in nlp.meta.lin
+        k += (j < nlp.meta.nln[rows[i]])
+      end
+      rows[i] += k
     end
   end
   return rows, cols

--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -185,21 +185,13 @@ function jac_structure!(
   lin_ind = 1:(nlp.meta.lin_nnzj)
   nlp.meta.nlin > 0 && jac_lin_structure!(nlp, view(rows, lin_ind), view(cols, lin_ind))
   for i in lin_ind
-    k = 0
-    for j in nlp.meta.nln
-      k += (j < nlp.meta.lin[rows[i]])
-    end
-    rows[i] += k
+    rows[i] += count(<(nlp.meta.lin[rows[i]]), nlp.meta.nln)
   end
   if nlp.meta.nnln > 0
     nln_ind = (nlp.meta.lin_nnzj + 1):(nlp.meta.lin_nnzj + nlp.meta.nln_nnzj)
     jac_nln_structure!(nlp, view(rows, nln_ind), view(cols, nln_ind))
     for i in nln_ind
-      k = 0
-      for j in nlp.meta.lin
-        k += (j < nlp.meta.nln[rows[i]])
-      end
-      rows[i] += k
+      rows[i] += count(<(nlp.meta.nln[rows[i]]), nlp.meta.lin)
     end
   end
   return rows, cols


### PR DESCRIPTION
Another bug. The shift in the rows was only valid when linear constraints are given first.

It now works with: 
- https://github.com/JuliaSmoothOptimizers/AmplNLReader.jl/tree/add-linear-API
- https://github.com/JuliaSmoothOptimizers/NLPModelsJuMP.jl/tree/add-linear-api
- https://github.com/JuliaSmoothOptimizers/LLSModels.jl/tree/add-linearAPI
- https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/tree/add-linearAPI