### PR TITLE
Adding non allocating increment functions

### DIFF
--- a/src/nlp/counters.jl
+++ b/src/nlp/counters.jl
@@ -51,6 +51,20 @@ for counter in fieldnames(Counters)
   end
 end
 
+# simple default API for incrementing counters
+for counter in fieldnames(Counters)
+  increment_counter = Symbol("increment_$(counter)!")
+  @eval begin
+    """
+        $($increment_counter)(nlp)
+
+    Increment the number of `$(split("$($counter)", "_")[2])` evaluations.
+    """
+    $increment_counter(nlp::AbstractNLPModel) = nlp.counters.$counter += 1
+    export $increment_counter
+  end
+end
+
 """
     increment!(nlp, s)
 

--- a/src/nlp/counters.jl
+++ b/src/nlp/counters.jl
@@ -70,8 +70,12 @@ end
 
 Increment counter `s` of problem `nlp`.
 """
-@inline function increment!(nlp::AbstractNLPModel, s::Symbol)
-  setproperty!(nlp.counters, s, getproperty(nlp.counters, s) + 1)
+function increment!(nlp::AbstractNLPModel, s::Symbol)
+  NLPModels.increment!(nlp, Val(s))
+end
+
+for fun in fieldnames(Counters)
+  @eval $NLPModels.increment!(nlp::AbstractNLPModel, ::Val{$(Meta.quot(fun))}) = nlp.counters.$fun += 1
 end
 
 """

--- a/src/nlp/counters.jl
+++ b/src/nlp/counters.jl
@@ -51,26 +51,12 @@ for counter in fieldnames(Counters)
   end
 end
 
-# simple default API for incrementing counters
-for counter in fieldnames(Counters)
-  increment_counter = Symbol("increment_$(counter)!")
-  @eval begin
-    """
-        $($increment_counter)(nlp)
-
-    Increment the number of `$(split("$($counter)", "_")[2])` evaluations.
-    """
-    $increment_counter(nlp::AbstractNLPModel) = nlp.counters.$counter += 1
-    export $increment_counter
-  end
-end
-
 """
     increment!(nlp, s)
 
 Increment counter `s` of problem `nlp`.
 """
-function increment!(nlp::AbstractNLPModel, s::Symbol)
+@inline function increment!(nlp::AbstractNLPModel, s::Symbol)
   NLPModels.increment!(nlp, Val(s))
 end
 

--- a/src/nls/counters.jl
+++ b/src/nls/counters.jl
@@ -73,40 +73,12 @@ for counter in fieldnames(Counters)
   end
 end
 
-# simple default API for incrementing counters
-for counter in fieldnames(NLSCounters)
-  counter == :counters && continue
-  increment_counter = Symbol("increment_$(counter)!")
-  @eval begin
-    """
-        $($increment_counter)(nls)
-
-    Increment the number of `$(split("$($counter)", "_")[2])` evaluations.
-    """
-    $increment_counter(nls::AbstractNLSModel) = nls.counters.$counter += 1
-    export $increment_counter
-  end
-end
-
-for counter in fieldnames(Counters)
-  increment_counter = Symbol("increment_$(counter)!")
-  @eval begin
-    """
-        $($increment_counter)(nls)
-
-    Increment the number of `$(split("$($counter)", "_")[2])` evaluations.
-    """
-    $increment_counter(nls::AbstractNLSModel) = nls.counters.counters.$counter += 1
-    export $increment_counter
-  end
-end
-
 """
     increment!(nls, s)
 
 Increment counter `s` of problem `nls`.
 """
-function increment!(nls::AbstractNLSModel, s::Symbol)
+@inline function increment!(nls::AbstractNLSModel, s::Symbol)
   NLPModels.increment!(nls, Val(s))
 end
 
@@ -114,7 +86,6 @@ for fun in fieldnames(NLSCounters)
   fun == :counters && continue
   @eval $NLPModels.increment!(nls::AbstractNLSModel, ::Val{$(Meta.quot(fun))}) = nls.counters.$fun += 1
 end
-
 
 for fun in fieldnames(Counters)
   @eval $NLPModels.increment!(nls::AbstractNLSModel, ::Val{$(Meta.quot(fun))}) = nls.counters.counters.$fun += 1

--- a/src/nls/counters.jl
+++ b/src/nls/counters.jl
@@ -73,6 +73,34 @@ for counter in fieldnames(Counters)
   end
 end
 
+# simple default API for incrementing counters
+for counter in fieldnames(NLSCounters)
+  counter == :counters && continue
+  increment_counter = Symbol("increment_$(counter)!")
+  @eval begin
+    """
+        $($increment_counter)(nls)
+
+    Increment the number of `$(split("$($counter)", "_")[2])` evaluations.
+    """
+    $increment_counter(nls::AbstractNLSModel) = nls.counters.$counter += 1
+    export $increment_counter
+  end
+end
+
+for counter in fieldnames(Counters)
+  increment_counter = Symbol("increment_$(counter)!")
+  @eval begin
+    """
+        $($increment_counter)(nls)
+
+    Increment the number of `$(split("$($counter)", "_")[2])` evaluations.
+    """
+    $increment_counter(nls::AbstractNLSModel) = nls.counters.counters.$counter += 1
+    export $increment_counter
+  end
+end
+
 function LinearOperators.reset!(nls::AbstractNLSModel)
   reset!(nls.counters)
   return nls

--- a/src/nls/counters.jl
+++ b/src/nls/counters.jl
@@ -101,6 +101,25 @@ for counter in fieldnames(Counters)
   end
 end
 
+"""
+    increment!(nls, s)
+
+Increment counter `s` of problem `nls`.
+"""
+function increment!(nls::AbstractNLSModel, s::Symbol)
+  NLPModels.increment!(nls, Val(s))
+end
+
+for fun in fieldnames(NLSCounters)
+  fun == :counters && continue
+  @eval $NLPModels.increment!(nls::AbstractNLSModel, ::Val{$(Meta.quot(fun))}) = nls.counters.$fun += 1
+end
+
+
+for fun in fieldnames(Counters)
+  @eval $NLPModels.increment!(nls::AbstractNLSModel, ::Val{$(Meta.quot(fun))}) = nls.counters.counters.$fun += 1
+end
+
 function LinearOperators.reset!(nls::AbstractNLSModel)
   reset!(nls.counters)
   return nls

--- a/test/nlp/counters.jl
+++ b/test/nlp/counters.jl
@@ -19,13 +19,3 @@
   reset!(nlp)
   @test sum_counters(nlp) == 0
 end
-
-@testset "Basic Increment check" begin
-  nlp = SimpleNLPModel()
-
-  increment_neval_obj!(nlp)
-  increment_neval_grad!(nlp)
-  @test sum_counters(nlp) == 2
-  reset!(nlp)
-  @test sum_counters(nlp) == 0
-end

--- a/test/nlp/counters.jl
+++ b/test/nlp/counters.jl
@@ -11,3 +11,13 @@
   reset!(nlp)
   @test sum_counters(nlp) == 0
 end
+
+@testset "Basic Increment check" begin
+  nlp = SimpleNLPModel()
+
+  increment_neval_obj!(nlp)
+  increment_neval_grad!(nlp)
+  @test sum_counters(nlp) == 2
+  reset!(nlp)
+  @test sum_counters(nlp) == 0
+end

--- a/test/nlp/counters.jl
+++ b/test/nlp/counters.jl
@@ -8,6 +8,14 @@
   obj(nlp, nlp.meta.x0)
   grad(nlp, nlp.meta.x0)
   @test sum_counters(nlp) == 2
+
+  for counter in fieldnames(Counters)
+    increment!(nlp, counter)
+  end
+  # sum all counters of problem `nlp` except 
+  # `cons`, `jac`, `jprod` and `jtprod` = 20-4+2
+  @test sum_counters(nlp) == 18
+
   reset!(nlp)
   @test sum_counters(nlp) == 0
 end

--- a/test/nlp/simple-model.jl
+++ b/test/nlp/simple-model.jl
@@ -141,7 +141,7 @@ end
 
 function NLPModels.jac_lin_coord!(nlp::SimpleNLPModel, x::AbstractVector, vals::AbstractVector)
   @lencheck 2 x vals
-  increment!(nlp, :neval_cons_lin)
+  increment!(nlp, :neval_jac_lin)
   vals .= [1, -2]
   return vals
 end

--- a/test/nls/counters.jl
+++ b/test/nls/counters.jl
@@ -27,16 +27,3 @@
   reset!(nls)
   @test sum_counters(nls) == 0
 end
-
-@testset "Basic increment of NLSCounters" begin
-  nls = SimpleNLSModel()
-  increment_neval_obj!(nls)
-  increment_neval_residual!(nls)
-  increment_neval_jac_residual!(nls)
-  @test neval_obj(nls) == 1
-  @test neval_residual(nls) == 1
-  @test neval_jac_residual(nls) == 1
-  @test sum_counters(nls) == 3
-  reset!(nls)
-  @test sum_counters(nls) == 0
-end

--- a/test/nls/counters.jl
+++ b/test/nls/counters.jl
@@ -10,3 +10,16 @@
   reset!(nls)
   @test sum_counters(nls) == 0
 end
+
+@testset "Basic increment of NLSCounters" begin
+  nls = SimpleNLSModel()
+  increment_neval_obj!(nls)
+  increment_neval_residual!(nls)
+  increment_neval_jac_residual!(nls)
+  @test neval_obj(nls) == 1
+  @test neval_residual(nls) == 1
+  @test neval_jac_residual(nls) == 1
+  @test sum_counters(nls) == 3
+  reset!(nls)
+  @test sum_counters(nls) == 0
+end

--- a/test/nls/counters.jl
+++ b/test/nls/counters.jl
@@ -1,12 +1,29 @@
 @testset "Increase coverage of NLSCounters" begin
+
   nls = SimpleNLSModel()
+
   obj(nls, nls.meta.x0)
   residual(nls, nls.meta.x0)
   jac_residual(nls, nls.meta.x0)
+
   @test neval_obj(nls) == 1
   @test neval_residual(nls) == 2
   @test neval_jac_residual(nls) == 1
   @test sum_counters(nls) == 4
+
+  for counter in fieldnames(Counters)
+    increment!(nls, counter)
+  end
+
+  for counter in fieldnames(NLSCounters)
+    counter == :counters && continue
+    increment!(nls, counter)
+  end
+
+  # sum all counters of problem `nlp` except 
+  # `cons`, `jac`, `jprod` and `jtprod` = 20+7-4+4
+  @test sum_counters(nls) == 27
+
   reset!(nls)
   @test sum_counters(nls) == 0
 end


### PR DESCRIPTION
This Pull Request is the follow-up from issue #405.

I realized that `getproperty` function from [here](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/blob/51841a1f092bd2fad0bfd1b9c7ec74c3cc94ace0/src/nls/counters.jl#L30) allocated memory. 

To be more precise it seems every function using `fieldnames(Counters)` like [here](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/blob/51841a1f092bd2fad0bfd1b9c7ec74c3cc94ace0/src/nls/counters.jl#L31) for example allocate memory.

When a NLSModel needs to increment its counters it calls the `getproperty` functions which means the `increment!` function allocates memory. To avoid this problem, thanks to @dpo we created new increment functions that don't allocate memory. 

Following this pull request it might be useful to replace every `increment!` function call by the new ones here that don't allocate memory anymore. It is worth noting every other function like `reset!` for example that also call `fieldnames(Counters)` also allocate memory and could be optimized in the future.
