### PR TITLE
`sum_counters` without allocations

### DIFF
--- a/src/nlp/counters.jl
+++ b/src/nlp/counters.jl
@@ -79,8 +79,13 @@ end
 Sum all counters of `counters` except `cons`, `jac`, `jprod` and `jtprod`.
 """
 function sum_counters(c::Counters)
-  fields = setdiff(fieldnames(Counters), [:neval_cons, :neval_jac, :neval_jprod, :neval_jtprod])
-  sum(getproperty(c, x) for x in fields)
+  sum = 0
+  for x in fieldnames(Counters)
+    if !(x in (:neval_cons, :neval_jac, :neval_jprod, :neval_jtprod))
+      sum += getproperty(c, x)
+    end
+  end
+  return sum
 end
 """
     sum_counters(nlp)


### PR DESCRIPTION
It was
```
julia> using NLPModels
julia> c = Counters();
julia> @time sum_counters(c);
  0.079578 seconds (295.66 k allocations: 15.417 MiB, 9.01% gc time, 99.93% compilation time)
julia> @time sum_counters(c);
  0.000021 seconds (15 allocations: 2.039 KiB)
```
and now becomes
```
julia> using NLPModels
julia> c = Counters();
julia> @time sum_counters(c);
  0.008422 seconds (32.14 k allocations: 1.756 MiB, 99.74% compilation time)
julia> @time sum_counters(c);
  0.000004 seconds
```