### PR TITLE
replace `@.` in `hess_op`

### DIFF
--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -1228,9 +1228,9 @@ function hess_op!(
   prod! = @closure (res, v, α, β) -> begin
     hprod!(nlp, x, v, Hv; obj_weight = obj_weight)
     if β == 0
-      @. res = α * Hv
+      res .= α .* Hv
     else
-      @. res = α * Hv + β * res
+      res .= α .* Hv .+ β .* res
     end
     return res
   end
@@ -1259,9 +1259,9 @@ function hess_op!(
   prod! = @closure (res, v, α, β) -> begin
     hprod!(nlp, rows, cols, vals, v, Hv)
     if β == 0
-      @. res = α * Hv
+      res .= α .* Hv
     else
-      @. res = α * Hv + β * res
+      res .= α .* Hv .+ β .* res
     end
     return res
   end
@@ -1290,9 +1290,9 @@ function hess_op!(
   prod! = @closure (res, v, α, β) -> begin
     hprod!(nlp, x, y, v, Hv; obj_weight = obj_weight)
     if β == 0
-      @. res = α * Hv
+      res .= α .* Hv
     else
-      @. res = α * Hv + β * res
+      res .= α .* Hv .+ β .* res
     end
     return res
   end


### PR DESCRIPTION
```
using NLPModels, NLPModelsTest # https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/pull/60
nlp = BROWNDEN()
print_nlp_allocations(nlp, test_allocs_nlpmodels(nlp))
```
returns
```
  Problem name: BROWNDEN_manual
                   obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
              hess_op!: ████████████████████ 1344.0
           hess_coord!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
                 grad!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
       hess_structure!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
                hprod!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
         hess_op_prod!: ██⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 96.0 
```
and after this PR, it returns
```
  Problem name: BROWNDEN_manual
                   obj: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
              hess_op!: ████████████████████ 1248.0
           hess_coord!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
                 grad!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
       hess_structure!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
                hprod!: ⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 0.0   
         hess_op_prod!: ██⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅⋅ 96.0  
```
We can do the same for `jac_op`, `jac_lin_op`, and `jac_nln_op`.

@geoffroyleconte @amontoison @dpo @abelsiqueira I am slightly surprised the `hess_op!` allocates and using the resulting linear operator for products also allocates. Any idea, where this is coming from? And, can we improve?