### PR TITLE
Version 0.19.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLPModels"
 uuid = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
-version = "0.19.0"
+version = "0.19.1"
 
 [deps]
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"


### PR DESCRIPTION
A minor release with the possibility of calling `obj` and `grad` allocation free for NLS problems.