### PR TITLE
add blocknlpmodels in the docs

### DIFF
--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -25,7 +25,6 @@ If you want to create your own interface, check these [Guidelines](@ref).
 - [PDENLPModels.jl](https://github.com/JuliaSmoothOptimizers/PDENLPModels.jl):
   For PDE-constrained problems.
 - [BlockNLPModels.jl](https://github.com/exanauts/BlockNLPModels.jl): For modeling block structured nonlinear optimization problems.
-- [BlockNLPAlgorithms.jl](https://github.com/exanauts/BlockNLPAlgorithms.jl): Implements popular decomposition algorithms such as dual decomposition and ADMM to solve block strucutred NLPs.
 
 ## Model internals
 

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -24,6 +24,8 @@ If you want to create your own interface, check these [Guidelines](@ref).
   Creates a linear least squares model.
 - [PDENLPModels.jl](https://github.com/JuliaSmoothOptimizers/PDENLPModels.jl):
   For PDE-constrained problems.
+- [BlockNLPModels.jl](https://github.com/exanauts/BlockNLPModels.jl): For modeling block structured nonlinear optimization problems
+- [BlockNLPAlgorithms.jl](https://github.com/exanauts/BlockNLPAlgorithms.jl): Implements popular decomposition algorithms such as dual decomposition and ADMM to solve block strucutred NLPs.
 
 ## Model internals
 

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -24,7 +24,7 @@ If you want to create your own interface, check these [Guidelines](@ref).
   Creates a linear least squares model.
 - [PDENLPModels.jl](https://github.com/JuliaSmoothOptimizers/PDENLPModels.jl):
   For PDE-constrained problems.
-- [BlockNLPModels.jl](https://github.com/exanauts/BlockNLPModels.jl): For modeling block structured nonlinear optimization problems
+- [BlockNLPModels.jl](https://github.com/exanauts/BlockNLPModels.jl): For modeling block structured nonlinear optimization problems.
 - [BlockNLPAlgorithms.jl](https://github.com/exanauts/BlockNLPAlgorithms.jl): Implements popular decomposition algorithms such as dual decomposition and ADMM to solve block strucutred NLPs.
 
 ## Model internals


### PR DESCRIPTION
Added details of `BlockNLPModels.jl` and `BlockNLPAlgorithms.jl` that implement `NLPModels.jl`'s API in the documentation.