### PR TITLE
Call cons! in objcons! for unconstrained

### DIFF
--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -132,7 +132,7 @@ function objcons!(nlp::AbstractNLPModel, x::AbstractVector, c::AbstractVector)
   @lencheck nlp.meta.nvar x
   @lencheck nlp.meta.ncon c
   f = obj(nlp, x)
-  nlp.meta.ncon > 0 && cons!(nlp, x, c)
+  cons!(nlp, x, c)
   return f, c
 end
 


### PR DESCRIPTION
This unifies the behavior with `objcons`. Otherwise, we have the strange behavior of having `neval_cons(nlp) = 0` after calling objcons!.