### PR TITLE
Error for nnzj mismatch

### DIFF
--- a/src/nlp/meta.jl
+++ b/src/nlp/meta.jl
@@ -143,6 +143,7 @@ function NLPModelMeta{T, S}(
   @lencheck nvar x0 lvar uvar
   @lencheck ncon y0 lcon ucon
   @rangecheck 1 ncon lin
+  @assert nnzj == lin_nnzj + nln_nnzj
 
   ifix = findall(lvar .== uvar)
   ilow = findall((lvar .> T(-Inf)) .& (uvar .== T(Inf)))


### PR DESCRIPTION
Added assertion error in [nlp/meta.jl](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/blob/main/src/nlp/meta.jl) if ``nnzj`` does not match ``lin_nnzj+nln_nnzj``, resolving #448.

Also related to https://github.com/JuliaSmoothOptimizers/NLPModelsModifiers.jl/issues/120 and possibly [CUTEst.jl](https://github.com/JuliaSmoothOptimizers/CUTEst.jl).