### PR TITLE
Add counters field in default counters macro

### DIFF
--- a/src/nlp/utils.jl
+++ b/src/nlp/utils.jl
@@ -131,5 +131,7 @@ macro default_counters(Model, inner)
   end))
   push!(ex.args, :(NLPModels.increment!(nlp::$(esc(Model)), s::Symbol) = increment!(nlp.$inner, s)))
   push!(ex.args, :(NLPModels.decrement!(nlp::$(esc(Model)), s::Symbol) = decrement!(nlp.$inner, s)))
+
+  push!(ex.args, :(Base.getproperty(nlp::$(esc(Model)), s::Symbol) = ( s == :counters ? nlp.$inner.counters : getfield(nlp ,s))))
   ex
 end

--- a/test/nlp/utils.jl
+++ b/test/nlp/utils.jl
@@ -22,4 +22,5 @@ end
   nlp = SuperNLPModel{Float64, Vector{Float64}}(SimpleNLPModel())
   increment!(nlp, :neval_obj)
   @test neval_obj(nlp.model) == 1
+  @test nlp.counters == nlp.model.counters
 end


### PR DESCRIPTION
We discussed this in [NLPModelsModifiers#121](https://github.com/JuliaSmoothOptimizers/NLPModelsModifiers.jl/issues/121). 

The macro `default_counters` should now add the field `counters` to `Model`.
I think this is the easiest solution. 

If you are ok with this, could we update this package version for compatibility with `NLPModelsModifiers.jl` ?