### PR TITLE
Add new NLPModelMeta constructor

### DIFF
--- a/src/nlp/meta.jl
+++ b/src/nlp/meta.jl
@@ -214,8 +214,55 @@ function NLPModelMeta{T, S}(
   )
 end
 
-NLPModelMeta(nvar; x0::S = zeros(nvar), kwargs...) where {S} =
+NLPModelMeta(nvar::Int; x0::S = zeros(nvar), kwargs...) where {S} =
   NLPModelMeta{eltype(S), S}(nvar, x0 = x0; kwargs...)
+
+function NLPModelMeta(
+  meta::NLPModelMeta{T, S};
+  nvar::Int = meta.nvar,
+  x0::S = meta.x0,
+  lvar::S = meta.lvar,
+  uvar::S = meta.uvar,
+  nlvb = meta.nlvb,
+  nlvo = meta.nlvo,
+  nlvc = meta.nlvc,
+  ncon = meta.ncon,
+  y0::S = meta.y0,
+  lcon::S = meta.lcon,
+  ucon::S = meta.ucon,
+  nnzo = meta.nnzo,
+  nnzj = meta.nnzj,
+  lin_nnzj = meta.lin_nnzj,
+  nln_nnzj = meta.nln_nnzj,
+  nnzh = meta.nnzh,
+  lin = meta.lin,
+  minimize = meta.minimize,
+  islp = meta.islp,
+  name = meta.name,
+) where {T, S}
+  NLPModelMeta{T, S}(
+    nvar,
+    x0 = x0,
+    lvar = lvar,
+    uvar = uvar,
+    nlvb = nlvb,
+    nlvo = nlvo,
+    nlvc = nlvc,
+    ncon = ncon,
+    y0 = y0,
+    lcon = lcon,
+    ucon = ucon,
+    nnzo = nnzo,
+    nnzj = nnzj,
+    lin_nnzj = lin_nnzj,
+    nln_nnzj = nln_nnzj,
+    nnzh = nnzh,
+    lin = lin,
+    minimize = minimize,
+    islp = islp,
+    name = name 
+  )
+end
 
 """
     reset_data!(nlp)

--- a/src/nlp/meta.jl
+++ b/src/nlp/meta.jl
@@ -26,9 +26,11 @@ Some of their components may be infinite to indicate that the corresponding boun
 
 ---
 
-    NLPModelMeta(nvar; kwargs...)
+    NLPModelMeta(nvar::Integer; kwargs...)
+    NLPModelMeta(meta::AbstractNLPModelMeta; kwargs...)
 
 Create an `NLPModelMeta` with `nvar` variables.
+Alternatively, create an `NLPModelMeta` copy from another `AbstractNLPModelMeta` with the ability to change the fields defined in the keyword arguments.
 The following keyword arguments are accepted:
 - `x0`: initial guess
 - `lvar`: vector of lower bounds

--- a/src/nlp/meta.jl
+++ b/src/nlp/meta.jl
@@ -143,6 +143,7 @@ function NLPModelMeta{T, S}(
   @lencheck nvar x0 lvar uvar
   @lencheck ncon y0 lcon ucon
   @rangecheck 1 ncon lin
+  @assert nnzj == lin_nnzj + nln_nnzj
 
   ifix = findall(lvar .== uvar)
   ilow = findall((lvar .> T(-Inf)) .& (uvar .== T(Inf)))

--- a/src/nlp/meta.jl
+++ b/src/nlp/meta.jl
@@ -30,7 +30,7 @@ Some of their components may be infinite to indicate that the corresponding boun
     NLPModelMeta(meta::AbstractNLPModelMeta; kwargs...)
 
 Create an `NLPModelMeta` with `nvar` variables.
-Alternatively, create an `NLPModelMeta` copy from another `AbstractNLPModelMeta` with the ability to change the fields defined in the keyword arguments.
+Alternatively, create an `NLPModelMeta` copy from another `AbstractNLPModelMeta`.
 The following keyword arguments are accepted:
 - `x0`: initial guess
 - `lvar`: vector of lower bounds

--- a/test/nlp/meta.jl
+++ b/test/nlp/meta.jl
@@ -1,3 +1,24 @@
 @testset "A problem with zero variables doesn't make sense." begin
   @test_throws ErrorException NLPModelMeta(0)
 end
+
+@testset "Meta copier." begin
+  nlp = SimpleNLPModel()
+  
+  # Check simple copy
+  meta = NLPModelMeta(nlp.meta)
+  for field in fieldnames(typeof(nlp.meta))
+    @test getfield(nlp.meta, field) == getfield(meta, field)
+  end
+
+  modif = Dict(:nnzh => 1, :x0 => [2.0; 2.0; 0.0], :nvar => 3, :lvar => zeros(3), :uvar => [1.0; 1.0; 0.0])
+  meta = NLPModelMeta(nlp.meta; modif...)
+  
+  for field in setdiff(fieldnames(typeof(nlp.meta)), union(keys(modif),[:ifix]))
+    @test getfield(nlp.meta, field) == getfield(meta, field)
+  end
+  for field in keys(modif)
+    @test getfield(meta, field) == modif[field]
+  end
+  @test meta.ifix == [3]
+end


### PR DESCRIPTION
We discussed this in #469

Added a function allowing to copy a NLPModelMeta but with the allowance to change some fields. 
For example, if one wants to modify the number of nonzero entries of the Hessian of some nlp, (this can be the case when one wants to use a diagonal Quasi-Newton approximation of the Hessian for example), one can write
```
meta = NLPModelMeta(nlp.meta, nnzh = nlp.meta.nvar)
```