### PR TITLE
Add `lin_nnzj` and `nln_nnzj` and docstrings for functions

### DIFF
--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -1344,6 +1344,30 @@ function hess_op!(
   return LinearOperator{T}(nlp.meta.nvar, nlp.meta.nvar, true, true, prod!, prod!, prod!)
 end
 
+"""
+    varscale(model::AbstractNLPModel)
+
+Return a vector containing the scaling factors for each variable in the model.
+This is typically used to normalize variables for numerical stability in solvers.
+
+By default, the scaling is model-dependent. If not overridden by the model, a vector of ones 
+is returned. Inspired by the AMPL scaling conventions.
+"""
 function varscale end
+
+"""
+    lagscale(model::AbstractNLPModel)
+
+Return a vector of scaling factors for the Lagrange multipliers associated with constraints.
+This can be used to improve numerical stability or condition number when solving KKT systems.
+"""
 function lagscale end
+
+"""
+    conscale(model::AbstractNLPModel)
+
+Return a vector of constraint scaling factors for the model.
+These are typically used to normalize constraints to have similar magnitudes and improve 
+convergence behavior in nonlinear solvers.
+"""
 function conscale end

--- a/src/nlp/show.jl
+++ b/src/nlp/show.jl
@@ -96,6 +96,9 @@ function lines_of_description(m::AbstractNLPModelMeta)
   push!(conlines, histline("linear", m.nlin, m.ncon), histline("nonlinear", m.nnln, m.ncon))
   push!(conlines, sparsityline("nnzj", m.nnzj, m.nvar * m.ncon))
 
+  push!(conlines, sparsityline("lin_nnzj", m.lin_nnzj, m.nvar * m.ncon))
+  push!(conlines, sparsityline("nln_nnzj", m.nln_nnzj, m.nvar * m.ncon))
+
   append!(varlines, repeat([" "^length(varlines[1])], length(conlines) - length(varlines)))
   lines = varlines .* conlines
 


### PR DESCRIPTION
This PR adds the `lin_nnzj` and `nln_nnzj` fields to the output of the `show` method for `AbstractNLPModelMeta` and documents the purpose and usage of the scaling-related functions exported in the NLPModels API: `varscale`, `lagscale`, and `conscale`.

Closes #485 
Closes #413 