### PR TITLE
Fix indent in docstring for NLS counters

### DIFF
--- a/src/nls/counters.jl
+++ b/src/nls/counters.jl
@@ -57,7 +57,7 @@ for counter in fieldnames(NLSCounters)
   counter == :counters && continue
   @eval begin
     """
-    $($counter)(nlp)
+        $($counter)(nlp)
 
     Get the number of `$(split("$($counter)", "_")[2])` evaluations.
     """


### PR DESCRIPTION
https://jso.dev/NLPModels.jl/dev/reference/#NLPModels.neval_hprod_residual-Tuple{AbstractNLSModel}

We need the same as here: https://github.com/JuliaSmoothOptimizers/NLPModels.jl/blob/d258d3550db5ebfb828a1edc049d1185a91587b7/src/nlp/counters.jl#L45