### PR TITLE
Separate default implementations from api.jl

### DIFF
--- a/src/NLPModels.jl
+++ b/src/NLPModels.jl
@@ -41,5 +41,7 @@ for f in ["utils", "api", "counters", "meta", "show", "tools"]
   include("nlp/$f.jl")
   include("nls/$f.jl")
 end
+include("nlp/defaults.jl")  # Include default implementations after API definitions
 
 end # module
+

--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -27,11 +27,7 @@ function obj end
 
 Evaluate ``∇f(x)``, the gradient of the objective function at `x`.
 """
-function grad(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
-  @lencheck nlp.meta.nvar x
-  g = S(undef, nlp.meta.nvar)
-  return grad!(nlp, x, g)
-end
+function grad end
 
 """
     g = grad!(nlp, x, g)
@@ -45,48 +41,21 @@ function grad! end
 
 Evaluate ``c(x)``, the constraints at `x`.
 """
-function cons(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
-  @lencheck nlp.meta.nvar x
-  c = S(undef, nlp.meta.ncon)
-  return cons!(nlp, x, c)
-end
+function cons end
 
 """
     c = cons!(nlp, x, c)
 
 Evaluate ``c(x)``, the constraints at `x` in place.
 """
-function cons!(nlp::AbstractNLPModel, x::AbstractVector, cx::AbstractVector)
-  @lencheck nlp.meta.nvar x
-  @lencheck nlp.meta.ncon cx
-  increment!(nlp, :neval_cons)
-  if nlp.meta.nlin > 0
-    if nlp.meta.nnln == 0
-      cons_lin!(nlp, x, cx)
-    else
-      cons_lin!(nlp, x, view(cx, nlp.meta.lin))
-    end
-  end
-  if nlp.meta.nnln > 0
-    if nlp.meta.nlin == 0
-      cons_nln!(nlp, x, cx)
-    else
-      cons_nln!(nlp, x, view(cx, nlp.meta.nln))
-    end
-  end
-  return cx
-end
+function cons! end
 
 """
     c = cons_lin(nlp, x)
 
 Evaluate the linear constraints at `x`.
 """
-function cons_lin(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
-  @lencheck nlp.meta.nvar x
-  c = S(undef, nlp.meta.nlin)
-  return cons_lin!(nlp, x, c)
-end
+function cons_lin end
 
 """
     c = cons_lin!(nlp, x, c)
@@ -100,11 +69,7 @@ function cons_lin! end
 
 Evaluate the nonlinear constraints at `x`.
 """
-function cons_nln(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
-  @lencheck nlp.meta.nvar x
-  c = S(undef, nlp.meta.nnln)
-  return cons_nln!(nlp, x, c)
-end
+function cons_nln end
 
 """
     c = cons_nln!(nlp, x, c)
@@ -115,11 +80,7 @@ function cons_nln! end
 
 function jth_con end
 
-function jth_congrad(nlp::AbstractNLPModel{T, S}, x::AbstractVector, j::Integer) where {T, S}
-  @lencheck nlp.meta.nvar x
-  g = S(undef, nlp.meta.nvar)
-  return jth_congrad!(nlp, x, j, g)
-end
+function jth_congrad end
 
 function jth_congrad! end
 
@@ -130,35 +91,21 @@ function jth_sparse_congrad end
 
 Evaluate ``f(x)`` and ``c(x)`` at `x`.
 """
-function objcons(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
-  @lencheck nlp.meta.nvar x
-  c = S(undef, nlp.meta.ncon)
-  return objcons!(nlp, x, c)
-end
+function objcons end
 
 """
     f, c = objcons!(nlp, x, c)
 
 Evaluate ``f(x)`` and ``c(x)`` at `x`. `c` is overwritten with the value of ``c(x)``.
 """
-function objcons!(nlp::AbstractNLPModel, x::AbstractVector, c::AbstractVector)
-  @lencheck nlp.meta.nvar x
-  @lencheck nlp.meta.ncon c
-  f = obj(nlp, x)
-  cons!(nlp, x, c)
-  return f, c
-end
+function objcons! end
 
 """
     f, g = objgrad(nlp, x)
 
 Evaluate ``f(x)`` and ``∇f(x)`` at `x`.
 """
-function objgrad(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
-  @lencheck nlp.meta.nvar x
-  g = S(undef, nlp.meta.nvar)
-  return objgrad!(nlp, x, g)
-end
+function objgrad end
 
 """
     f, g = objgrad!(nlp, x, g)
@@ -166,70 +113,28 @@ end
 Evaluate ``f(x)`` and ``∇f(x)`` at `x`. `g` is overwritten with the
 value of ``∇f(x)``.
 """
-function objgrad!(nlp::AbstractNLPModel, x::AbstractVector, g::AbstractVector)
-  @lencheck nlp.meta.nvar x g
-  f = obj(nlp, x)
-  grad!(nlp, x, g)
-  return f, g
-end
+function objgrad! end
 
 """
     (rows,cols) = jac_structure(nlp)
 
 Return the structure of the constraints Jacobian in sparse coordinate format.
 """
-function jac_structure(nlp::AbstractNLPModel)
-  rows = Vector{Int}(undef, nlp.meta.nnzj)
-  cols = Vector{Int}(undef, nlp.meta.nnzj)
-  jac_structure!(nlp, rows, cols)
-end
+function jac_structure end
 
 """
     jac_structure!(nlp, rows, cols)
 
 Return the structure of the constraints Jacobian in sparse coordinate format in place.
 """
-function jac_structure!(
-  nlp::AbstractNLPModel,
-  rows::AbstractVector{T},
-  cols::AbstractVector{T},
-) where {T}
-  @lencheck nlp.meta.nnzj rows cols
-  lin_ind = 1:(nlp.meta.lin_nnzj)
-  if nlp.meta.nlin > 0
-    if nlp.meta.nnln == 0
-      jac_lin_structure!(nlp, rows, cols)
-    else
-      jac_lin_structure!(nlp, view(rows, lin_ind), view(cols, lin_ind))
-      for i in lin_ind
-        rows[i] += count(x < nlp.meta.lin[rows[i]] for x in nlp.meta.nln)
-      end
-    end
-  end
-  if nlp.meta.nnln > 0
-    if nlp.meta.nlin == 0
-      jac_nln_structure!(nlp, rows, cols)
-    else
-      nln_ind = (nlp.meta.lin_nnzj + 1):(nlp.meta.lin_nnzj + nlp.meta.nln_nnzj)
-      jac_nln_structure!(nlp, view(rows, nln_ind), view(cols, nln_ind))
-      for i in nln_ind
-        rows[i] += count(x < nlp.meta.nln[rows[i]] for x in nlp.meta.lin)
-      end
-    end
-  end
-  return rows, cols
-end
+function jac_structure! end
 
 """
     (rows,cols) = jac_lin_structure(nlp)
 
 Return the structure of the linear constraints Jacobian in sparse coordinate format.
 """
-function jac_lin_structure(nlp::AbstractNLPModel)
-  rows = Vector{Int}(undef, nlp.meta.lin_nnzj)
-  cols = Vector{Int}(undef, nlp.meta.lin_nnzj)
-  jac_lin_structure!(nlp, rows, cols)
-end
+function jac_lin_structure end
 
 """
     jac_lin_structure!(nlp, rows, cols)
@@ -243,11 +148,7 @@ function jac_lin_structure! end
 
 Return the structure of the nonlinear constraints Jacobian in sparse coordinate format.
 """
-function jac_nln_structure(nlp::AbstractNLPModel)
-  rows = Vector{Int}(undef, nlp.meta.nln_nnzj)
-  cols = Vector{Int}(undef, nlp.meta.nln_nnzj)
-  jac_nln_structure!(nlp, rows, cols)
-end
+function jac_nln_structure end
 
 """
     jac_nln_structure!(nlp, rows, cols)

--- a/src/nlp/defaults.jl
+++ b/src/nlp/defaults.jl
@@ -1,0 +1,131 @@
+# Default implementations for NLP API functions
+# This file contains the default implementations that were separated from api.jl
+# to improve code organization and separate API definitions from implementations.
+
+# Default implementations for core functions
+function grad(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
+  @lencheck nlp.meta.nvar x
+  g = S(undef, nlp.meta.nvar)
+  return grad!(nlp, x, g)
+end
+
+function cons(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
+  @lencheck nlp.meta.nvar x
+  c = S(undef, nlp.meta.ncon)
+  return cons!(nlp, x, c)
+end
+
+function cons!(nlp::AbstractNLPModel, x::AbstractVector, cx::AbstractVector)
+  @lencheck nlp.meta.nvar x
+  @lencheck nlp.meta.ncon cx
+  increment!(nlp, :neval_cons)
+  if nlp.meta.nlin > 0
+    if nlp.meta.nnln == 0
+      cons_lin!(nlp, x, cx)
+    else
+      cons_lin!(nlp, x, view(cx, nlp.meta.lin))
+    end
+  end
+  if nlp.meta.nnln > 0
+    if nlp.meta.nlin == 0
+      cons_nln!(nlp, x, cx)
+    else
+      cons_nln!(nlp, x, view(cx, nlp.meta.nln))
+    end
+  end
+  return cx
+end
+
+function cons_lin(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
+  @lencheck nlp.meta.nvar x
+  c = S(undef, nlp.meta.nlin)
+  return cons_lin!(nlp, x, c)
+end
+
+function cons_nln(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
+  @lencheck nlp.meta.nvar x
+  c = S(undef, nlp.meta.nnln)
+  return cons_nln!(nlp, x, c)
+end
+
+function jth_congrad(nlp::AbstractNLPModel{T, S}, x::AbstractVector, j::Integer) where {T, S}
+  @lencheck nlp.meta.nvar x
+  g = S(undef, nlp.meta.nvar)
+  return jth_congrad!(nlp, x, j, g)
+end
+
+function objcons(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
+  @lencheck nlp.meta.nvar x
+  c = S(undef, nlp.meta.ncon)
+  return objcons!(nlp, x, c)
+end
+
+function objcons!(nlp::AbstractNLPModel, x::AbstractVector, c::AbstractVector)
+  @lencheck nlp.meta.nvar x
+  @lencheck nlp.meta.ncon c
+  f = obj(nlp, x)
+  cons!(nlp, x, c)
+  return f, c
+end
+
+function objgrad(nlp::AbstractNLPModel{T, S}, x::AbstractVector) where {T, S}
+  @lencheck nlp.meta.nvar x
+  g = S(undef, nlp.meta.nvar)
+  return objgrad!(nlp, x, g)
+end
+
+function objgrad!(nlp::AbstractNLPModel, x::AbstractVector, g::AbstractVector)
+  @lencheck nlp.meta.nvar x g
+  f = obj(nlp, x)
+  grad!(nlp, x, g)
+  return f, g
+end
+
+function jac_structure(nlp::AbstractNLPModel)
+  rows = Vector{Int}(undef, nlp.meta.nnzj)
+  cols = Vector{Int}(undef, nlp.meta.nnzj)
+  jac_structure!(nlp, rows, cols)
+end
+
+function jac_structure!(
+  nlp::AbstractNLPModel,
+  rows::AbstractVector{T},
+  cols::AbstractVector{T},
+) where {T}
+  @lencheck nlp.meta.nnzj rows cols
+  lin_ind = 1:(nlp.meta.lin_nnzj)
+  if nlp.meta.nlin > 0
+    if nlp.meta.nnln == 0
+      jac_lin_structure!(nlp, rows, cols)
+    else
+      jac_lin_structure!(nlp, view(rows, lin_ind), view(cols, lin_ind))
+      for i in lin_ind
+        rows[i] += count(x < nlp.meta.lin[rows[i]] for x in nlp.meta.nln)
+      end
+    end
+  end
+  if nlp.meta.nnln > 0
+    if nlp.meta.nlin == 0
+      jac_nln_structure!(nlp, rows, cols)
+    else
+      nln_ind = (nlp.meta.lin_nnzj + 1):(nlp.meta.lin_nnzj + nlp.meta.nln_nnzj)
+      jac_nln_structure!(nlp, view(rows, nln_ind), view(cols, nln_ind))
+      for i in nln_ind
+        rows[i] += count(x < nlp.meta.nln[rows[i]] for x in nlp.meta.lin)
+      end
+    end
+  end
+  return rows, cols
+end
+
+function jac_lin_structure(nlp::AbstractNLPModel)
+  rows = Vector{Int}(undef, nlp.meta.lin_nnzj)
+  cols = Vector{Int}(undef, nlp.meta.lin_nnzj)
+  jac_lin_structure!(nlp, rows, cols)
+end
+
+function jac_nln_structure(nlp::AbstractNLPModel)
+  rows = Vector{Int}(undef, nlp.meta.nln_nnzj)
+  cols = Vector{Int}(undef, nlp.meta.nln_nnzj)
+  jac_nln_structure!(nlp, rows, cols)
+end


### PR DESCRIPTION
- Create src/nlp/defaults.jl for default implementations
- Update src/NLPModels.jl to include defaults.jl after api.jl
- Move default implementations from api.jl to defaults.jl
- Replace implementations with function stubs in api.jl
- Resolves method overwriting warnings during precompilation

Functions refactored:
- grad(), cons(), cons!(), cons_lin(), cons_nln()
- jth_congrad(), objcons(), objcons!(), objgrad(), objgrad!()
- jac_structure(), jac_structure!(), jac_lin_structure(), jac_nln_structure()

Closes #385 