### PR TITLE
Version 0.22.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLPModels"
 uuid = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
-version = "0.21.5"
+version = "0.22.0"
 
 [deps]
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"


### PR DESCRIPTION
Release notes:

## Breaking changes
- drop support for Julia 1.6
- objcons! with in-place residual not defined for NLS
- the jac_lin* functions no longer take an x argument.