### PR TITLE
Implement default jac_lin* API to patch 0.22

### DIFF
--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -316,10 +316,10 @@ overwriting `vals`.
 """
 function jac_lin_coord! end
 
-@deprecate jac_lin_coord!(nlp::AbstractNLPModel, x::AbstractVector, vals::AbstractVector) jac_lin_coord!(
-  nlp,
-  vals,
-)
+function jac_lin_coord!(nlp::AbstractNLPModel, vals::AbstractVector)
+  @warn "Calling deprecated method jac_lin_coord!(nlp, x, vals). Use jac_lin_coord!(nlp, vals) instead." deprecated=DeprecationWarning()
+  return jac_lin_coord!(nlp, nlp.meta.x0, vals)
+end
 
 """
     vals = jac_lin_coord(nlp)
@@ -446,6 +446,8 @@ function jprod_lin(nlp::AbstractNLPModel{T, S}, v::AbstractVector) where {T, S}
   return jprod_lin!(nlp, v, Jv)
 end
 
+@deprecate jprod_lin(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector) jprod_lin(nlp, v)
+
 """
     Jv = jprod_lin!(nlp, v, Jv)
 
@@ -453,13 +455,11 @@ Evaluate ``J(x)v``, the linear Jacobian-vector product at `x` in place.
 """
 function jprod_lin! end
 
-@deprecate jprod_lin(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector) jprod_lin(nlp, v)
-@deprecate jprod_lin!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  v::AbstractVector,
-  Jv::AbstractVector,
-) jprod_lin!(nlp, v, Jv)
+function jprod_lin!(nlp::AbstractNLPModel, v::AbstractVector, Jv::AbstractVector)
+  @warn "Calling deprecated method jprod_lin!(nlp, x, v, Jv). Use jprod_lin!(nlp, v, Jv) instead." deprecated=DeprecationWarning()
+  jprod_lin!(nlp, nlp.meta.x0, v, Jv)
+  return Jv
+end
 
 """
     Jv = jprod_lin!(nlp, rows, cols, vals, v, Jv)
@@ -593,6 +593,11 @@ function jtprod_lin(nlp::AbstractNLPModel{T, S}, v::AbstractVector) where {T, S}
   return jtprod_lin!(nlp, v, Jtv)
 end
 
+@deprecate jtprod_lin(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector) jtprod_lin(
+  nlp,
+  v,
+)
+
 """
     Jtv = jtprod_lin!(nlp, v, Jtv)
 
@@ -600,16 +605,11 @@ Evaluate ``J(x)^Tv``, the linear transposed-Jacobian-vector product at `x` in pl
 """
 function jtprod_lin! end
 
-@deprecate jtprod_lin(nlp::AbstractNLPModel, x::AbstractVector, v::AbstractVector) jtprod_lin(
-  nlp,
-  v,
-)
-@deprecate jtprod_lin!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  v::AbstractVector,
-  Jtv::AbstractVector,
-) jtprod_lin!(nlp, v, Jtv)
+function jtprod_lin!(nlp::AbstractNLPModel, v::AbstractVector, Jtv::AbstractVector)
+  @warn "Calling deprecated method jtprod_lin!(nlp, x, v, Jtv). Use jtprod_lin!(nlp, v, Jtv) instead." deprecated=DeprecationWarning()
+  jtprod_lin!(nlp, nlp.meta.x0, v, Jtv)
+  return Jtv
+end
 
 """
     Jtv = jtprod_lin!(nlp, rows, cols, vals, v, Jtv)
@@ -813,12 +813,7 @@ function jac_lin_op!(
   return LinearOperator{T}(nlp.meta.nlin, nlp.meta.nvar, false, false, prod!, ctprod!, ctprod!)
 end
 
-@deprecate jac_lin_op!(
-  nlp::AbstractNLPModel,
-  x::AbstractVector,
-  Jv::AbstractVector,
-  Jtv::AbstractVector,
-) jac_lin_op!(nlp, Jv, Jtv)
+@deprecate jac_lin_op!(nlp::AbstractNLPModel, x::AbstractVector, Jv::AbstractVector, Jtv::AbstractVector) jac_lin_op!(nlp, Jv, Jtv)
 
 """
     J = jac_lin_op!(nlp, rows, cols, vals, Jv, Jtv)

--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -317,7 +317,7 @@ overwriting `vals`.
 function jac_lin_coord! end
 
 function jac_lin_coord!(nlp::AbstractNLPModel, vals::AbstractVector)
-  @warn "Calling deprecated method jac_lin_coord!(nlp, x, vals). Use jac_lin_coord!(nlp, vals) instead."
+  # @warn "Calling deprecated method jac_lin_coord!(nlp, x, vals). Use jac_lin_coord!(nlp, vals) instead."
   return jac_lin_coord!(nlp, nlp.meta.x0, vals)
 end
 
@@ -456,7 +456,7 @@ Evaluate ``J(x)v``, the linear Jacobian-vector product at `x` in place.
 function jprod_lin! end
 
 function jprod_lin!(nlp::AbstractNLPModel, v::AbstractVector, Jv::AbstractVector)
-  @warn "Calling deprecated method jprod_lin!(nlp, x, v, Jv). Use jprod_lin!(nlp, v, Jv) instead."
+  # @warn "Calling deprecated method jprod_lin!(nlp, x, v, Jv). Use jprod_lin!(nlp, v, Jv) instead."
   jprod_lin!(nlp, nlp.meta.x0, v, Jv)
   return Jv
 end
@@ -606,7 +606,7 @@ Evaluate ``J(x)^Tv``, the linear transposed-Jacobian-vector product at `x` in pl
 function jtprod_lin! end
 
 function jtprod_lin!(nlp::AbstractNLPModel, v::AbstractVector, Jtv::AbstractVector)
-  @warn "Calling deprecated method jtprod_lin!(nlp, x, v, Jtv). Use jtprod_lin!(nlp, v, Jtv) instead."
+  # @warn "Calling deprecated method jtprod_lin!(nlp, x, v, Jtv). Use jtprod_lin!(nlp, v, Jtv) instead."
   jtprod_lin!(nlp, nlp.meta.x0, v, Jtv)
   return Jtv
 end

--- a/src/nlp/api.jl
+++ b/src/nlp/api.jl
@@ -317,7 +317,7 @@ overwriting `vals`.
 function jac_lin_coord! end
 
 function jac_lin_coord!(nlp::AbstractNLPModel, vals::AbstractVector)
-  @warn "Calling deprecated method jac_lin_coord!(nlp, x, vals). Use jac_lin_coord!(nlp, vals) instead." deprecated=DeprecationWarning()
+  @warn "Calling deprecated method jac_lin_coord!(nlp, x, vals). Use jac_lin_coord!(nlp, vals) instead."
   return jac_lin_coord!(nlp, nlp.meta.x0, vals)
 end
 
@@ -456,7 +456,7 @@ Evaluate ``J(x)v``, the linear Jacobian-vector product at `x` in place.
 function jprod_lin! end
 
 function jprod_lin!(nlp::AbstractNLPModel, v::AbstractVector, Jv::AbstractVector)
-  @warn "Calling deprecated method jprod_lin!(nlp, x, v, Jv). Use jprod_lin!(nlp, v, Jv) instead." deprecated=DeprecationWarning()
+  @warn "Calling deprecated method jprod_lin!(nlp, x, v, Jv). Use jprod_lin!(nlp, v, Jv) instead."
   jprod_lin!(nlp, nlp.meta.x0, v, Jv)
   return Jv
 end
@@ -606,7 +606,7 @@ Evaluate ``J(x)^Tv``, the linear transposed-Jacobian-vector product at `x` in pl
 function jtprod_lin! end
 
 function jtprod_lin!(nlp::AbstractNLPModel, v::AbstractVector, Jtv::AbstractVector)
-  @warn "Calling deprecated method jtprod_lin!(nlp, x, v, Jtv). Use jtprod_lin!(nlp, v, Jtv) instead." deprecated=DeprecationWarning()
+  @warn "Calling deprecated method jtprod_lin!(nlp, x, v, Jtv). Use jtprod_lin!(nlp, v, Jtv) instead."
   jtprod_lin!(nlp, nlp.meta.x0, v, Jtv)
   return Jtv
 end


### PR DESCRIPTION
A suggestion of changes to make 0.22 less breaking.
I tested NLPModelsModifiers, NLPModelsTest, QuadraticModels, ADNLPModels .

Changes are very minor, for instance for NLPModelsModifiers and NLPModelsTest:
- Testing a poor x would no longer fail
- The show function of nlp has also changed

QuadraticModels and ADNLPModels were not requiring any modification.

I commented out the warn messages in some places, because it allocates.


