### PR TITLE
Release 0.21.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLPModels"
 uuid = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
-version = "0.21.5"
+version = "0.21.6"
 
 [deps]
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
@@ -11,7 +11,11 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 FastClosures = "0.3.0"
+LinearAlgebra = "1.10"
 LinearOperators = "2"
+Printf = "1.10"
+SparseArrays = "1.10"
+Test = "1.10"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
I tag a new release such that #529 can be used in `UnoSolver.jl`, `MadNLP.jl` and `NLPModelsJuMP.jl`.

It can be also relevant to use it to dispatch to quasi-Newton approximation in `NLPModelsIpopt.jl` when the Hessian of the Lagrangian is not available.

cc @frapac